### PR TITLE
implements cache strategy for ModelLoader class on 3d-web-client-core package

### DIFF
--- a/example/web-client/public/index.html
+++ b/example/web-client/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg" href="/favicon.svg" />
+    <link rel="icon" type="image/svg" href="/web-client/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MML 3D Web Experience</title>
     <link rel="stylesheet" href="/web-client/style.css" />

--- a/example/web-client/src/Sun.ts
+++ b/example/web-client/src/Sun.ts
@@ -30,9 +30,11 @@ export class Sun extends Group {
     this.add(this.directionalLight);
   }
 
-  private updateCharacterPosition(position: Vector3) {
-    const newPosition = position.clone().add(this.sunOffset);
-    this.directionalLight.position.set(newPosition.x, newPosition.y, newPosition.z);
-    this.directionalLight.updateMatrixWorld();
+  public updateCharacterPosition(position: Vector3 | undefined) {
+    if (!position) return;
+    const newSunPosition = position.clone().add(this.sunOffset);
+    this.directionalLight.position.set(newSunPosition.x, newSunPosition.y, newSunPosition.z);
+    this.directionalLight.target.position.copy(position.clone());
+    this.directionalLight.target.updateMatrixWorld();
   }
 }

--- a/example/web-client/src/Sun.ts
+++ b/example/web-client/src/Sun.ts
@@ -2,8 +2,8 @@ import { DirectionalLight, Group, OrthographicCamera, Vector3 } from "three";
 
 export class Sun extends Group {
   private readonly sunOffset: Vector3 = new Vector3(50, 80, 35);
-  private readonly shadowResolution: number = 8192;
-  private readonly shadowCamFrustum: number = 25;
+  private readonly shadowResolution: number = 4096;
+  private readonly shadowCamFrustum: number = 21;
 
   private readonly shadowCamera: OrthographicCamera;
   private readonly directionalLight: DirectionalLight;

--- a/example/web-client/src/index.ts
+++ b/example/web-client/src/index.ts
@@ -36,6 +36,8 @@ export class App {
   private readonly modelsPath: string = "/web-client/assets/models";
   private readonly characterDescription: CharacterDescription | null = null;
 
+  private readonly sun: Sun;
+
   constructor() {
     this.scene = new Scene();
     this.scene.fog = new Fog(0xc7cad0, 30, 210);
@@ -109,7 +111,8 @@ export class App {
     );
 
     this.group.add(mmlComposition.group);
-    this.group.add(new Sun());
+    this.sun = new Sun();
+    this.group.add(this.sun);
 
     const room = new Room();
     this.collisionsManager.addMeshesGroup(room);
@@ -128,6 +131,7 @@ export class App {
     this.timeManager.update();
     this.characterManager.update();
     this.cameraManager.update();
+    this.sun.updateCharacterPosition(this.characterManager.character?.position);
     this.composer.render(this.timeManager.time);
     requestAnimationFrame(() => {
       this.update();

--- a/packages/3d-web-client-core/src/character/CharacterModel.ts
+++ b/packages/3d-web-client-core/src/character/CharacterModel.ts
@@ -11,10 +11,11 @@ import {
 import { CharacterDescription } from "./Character";
 import { CharacterMaterial } from "./CharacterMaterial";
 import { AnimationState } from "./CharacterState";
-import { ModelLoader } from "./ModelLoader";
+import MODEL_LOADER from "./ModelLoader";
 
 export class CharacterModel {
-  private modelLoader: ModelLoader = new ModelLoader();
+  /* TODO: pick between below eager instantiation or ModelLoader.getInstance() lazy one */
+  private modelLoader = MODEL_LOADER;
 
   public mesh: Object3D | null = null;
   public material: CharacterMaterial = new CharacterMaterial();

--- a/packages/3d-web-client-core/src/character/ModelLoader.ts
+++ b/packages/3d-web-client-core/src/character/ModelLoader.ts
@@ -1,68 +1,156 @@
 import { AnimationClip, LoadingManager, Object3D } from "three";
-import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
-import { GLTF, GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTF, GLTFLoader as ThreeGLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+class CachedGLTFLoader extends ThreeGLTFLoader {
+  private blobCache: Map<string, string>;
+
+  constructor(manager?: LoadingManager) {
+    super(manager);
+    this.blobCache = new Map();
+  }
+
+  setBlobUrl(originalUrl: string, blobUrl: string) {
+    this.blobCache.set(originalUrl, blobUrl);
+  }
+
+  getBlobUrl(originalUrl: string): string | undefined {
+    return this.blobCache.get(originalUrl);
+  }
+
+  load(
+    url: string,
+    onLoad: (gltf: GLTF) => void,
+    onProgress?: ((event: ProgressEvent<EventTarget>) => void) | undefined,
+    onError?: ((event: ErrorEvent) => void) | undefined,
+  ): void {
+    const blobUrl = this.getBlobUrl(url);
+    if (blobUrl) {
+      console.log(`Loading cached ${url.split("/").pop()}`);
+      super.load(blobUrl, onLoad, onProgress, onError);
+    } else {
+      super.load(url, onLoad, onProgress, onError);
+    }
+  }
+}
+
+class LRUCache<K, V> {
+  private maxSize: number;
+  private cache: Map<K, V>;
+
+  constructor(maxSize: number = 100) {
+    this.maxSize = maxSize;
+    this.cache = new Map();
+  }
+
+  get(key: K): V | undefined {
+    const item = this.cache.get(key);
+    if (item) {
+      this.cache.delete(key);
+      this.cache.set(key, item);
+    }
+    return item;
+  }
+
+  set(key: K, value: V): void {
+    if (this.cache.size >= this.maxSize) {
+      const oldestKey = this.cache.keys().next().value;
+      this.cache.delete(oldestKey);
+    }
+    this.cache.set(key, value);
+  }
+}
+
+interface CachedModel {
+  blob: Blob;
+  originalExtension: string;
+}
 
 export class ModelLoader {
-  private debug: boolean = false;
-  private readonly loadingManager: LoadingManager;
-  private readonly fbxLoader: FBXLoader;
-  private readonly gltfLoader: GLTFLoader;
+  private static instance: ModelLoader | null = null;
 
-  constructor() {
+  private readonly loadingManager: LoadingManager;
+  private readonly gltfLoader: CachedGLTFLoader;
+  private modelCache: LRUCache<string, CachedModel>;
+  private ongoingLoads: Map<string, Promise<Object3D | AnimationClip | undefined>> = new Map();
+
+  constructor(maxCacheSize: number = 100) {
     this.loadingManager = new LoadingManager();
-    this.fbxLoader = new FBXLoader(this.loadingManager);
-    this.gltfLoader = new GLTFLoader(this.loadingManager);
+    this.gltfLoader = new CachedGLTFLoader(this.loadingManager);
+    this.modelCache = new LRUCache(maxCacheSize);
+  }
+
+  /* TODO: decide between below lazy initialization or eager on this file's bottom export */
+  static getInstance(): ModelLoader {
+    if (!ModelLoader.instance) {
+      console.log("Instantiating ModelLoader");
+      ModelLoader.instance = new ModelLoader();
+    }
+    return ModelLoader.instance;
   }
 
   async load(
     fileUrl: string,
     fileType: "model" | "animation",
   ): Promise<Object3D | AnimationClip | undefined> {
-    const extension = fileUrl.split(".").pop();
-    if (typeof extension === "undefined") {
-      console.error(`Unable to identify model type from ${fileUrl}`);
-      return;
+    const cachedModel = this.modelCache.get(fileUrl);
+
+    if (cachedModel) {
+      const blobURL = URL.createObjectURL(cachedModel.blob);
+      this.gltfLoader.setBlobUrl(fileUrl, blobURL);
+      return this.loadFromUrl(fileUrl, fileType, cachedModel.originalExtension);
+    } else {
+      console.log(`Loading ${fileUrl} from server`);
+      const ongoingLoad = this.ongoingLoads.get(fileUrl);
+      if (ongoingLoad) return ongoingLoad;
+
+      const loadPromise = fetch(fileUrl)
+        .then((response) => response.blob())
+        .then((blob) => {
+          const originalExtension = fileUrl.split(".").pop() || "";
+          this.modelCache.set(fileUrl, { blob, originalExtension });
+          const blobURL = URL.createObjectURL(blob);
+          this.ongoingLoads.delete(fileUrl);
+          return this.loadFromUrl(blobURL, fileType, originalExtension);
+        });
+
+      this.ongoingLoads.set(fileUrl, loadPromise);
+      return loadPromise;
     }
-    const name = fileUrl.split("/").pop()!.replace(`.${extension!}`, "");
-    if (this.debug) {
-      console.log(`Loading ${extension} model ${name} from ${fileUrl}`);
-    }
+  }
+
+  private async loadFromUrl(
+    url: string,
+    fileType: "model" | "animation",
+    extension: string,
+  ): Promise<Object3D | AnimationClip | undefined> {
     if (["gltf", "glb"].includes(extension)) {
       return new Promise((resolve, reject) => {
         this.gltfLoader.load(
-          fileUrl,
+          url,
           (object: GLTF) => {
             if (fileType === "model") {
               resolve(object.scene as Object3D);
             } else if (fileType === "animation") {
               resolve(object.animations[0] as AnimationClip);
             } else {
-              const error = `Trying to load unknown ${fileType} type of element from file ${fileUrl}`;
+              const error = `Trying to load unknown ${fileType} type of element from file ${url}`;
               console.error(error);
               reject(error);
             }
           },
           undefined,
           (error) => {
-            console.error(`Error loading GL(B|TF) from ${fileUrl}: ${error}`);
+            console.error(`Error loading GL(B|TF) from ${url}: ${error}`);
             reject(error);
           },
         );
       });
-    } else if (extension === "fbx") {
-      return new Promise((resolve, reject) => {
-        this.fbxLoader.load(
-          fileUrl,
-          (object: Object3D) => {
-            resolve(object as Object3D);
-          },
-          undefined,
-          (error) => {
-            console.error(`Error loading FBX from ${fileUrl}: ${error}`);
-            reject(error);
-          },
-        );
-      });
+    } else {
+      console.error(`Error: can't recognize ${url} extension: ${extension}`);
     }
   }
 }
+
+/* TODO: decide between below eager initialization or static getInstance() lazy one */
+const MODEL_LOADER = ModelLoader.getInstance();
+export default MODEL_LOADER;

--- a/packages/3d-web-client-core/src/rendering/composer.ts
+++ b/packages/3d-web-client-core/src/rendering/composer.ts
@@ -103,7 +103,6 @@ export class Composer {
     new RGBELoader(new LoadingManager()).load(
       url,
       (texture) => {
-        console.log(texture);
         const envMap = pmremGenerator!.fromEquirectangular(texture).texture;
         if (envMap) {
           envMap.colorSpace = LinearSRGBColorSpace;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["./src/**/*.ts", "./test/**/*.ts"]
+  "include": ["./packages/**/*.ts", "./example/**/*.ts"]
 }


### PR DESCRIPTION
This PR drafts a cache strategy for the `ModelLoader` character class on `3d-web-client-core` package and aims to prevent the client from fetching character assets once loaded they were loaded already. This is particularly useful when retrieving different assets from the same file (as `skinnedMesh` and some animation clip coming from the same GLB file) or joining a world with multiple connected clients.

This caching strategy will be associated with additional strategies (to be implemented) to prevent loading, such as using ThreeJS skeleton utils to create clones of a given Object3D model already spawned instead of invoking the load method, and then creating their respective animation mixers for each instance (assuming the new client joining will use a 3D model already being used by any other client).

In the same PR there are some minor fixes as well, such as:
- removing rogue console.logs;
- fixing the URL of favicon URL given its new route to be served from;
- fixing the sun position and matrixWorld updates on web-client.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [X] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
