### PR TITLE
fixes post-processing chain and improves tweakpane

### DIFF
--- a/packages/3d-web-client-core/src/character/CharacterMaterial.ts
+++ b/packages/3d-web-client-core/src/character/CharacterMaterial.ts
@@ -22,12 +22,24 @@ export class CharacterMaterial extends MeshPhysicalMaterial {
     this.roughness = characterValues.material.roughness;
     this.ior = characterValues.material.ior;
     this.thickness = characterValues.material.thickness;
-    this.specularColor = characterValues.material.specularColor;
+    this.specularColor = new Color().setRGB(
+      characterValues.material.specularColor.r,
+      characterValues.material.specularColor.g,
+      characterValues.material.specularColor.b,
+    );
     this.specularIntensity = characterValues.material.specularIntensity;
-    this.emissive = characterValues.material.emissive;
+    this.emissive = new Color().setRGB(
+      characterValues.material.emissive.r,
+      characterValues.material.emissive.g,
+      characterValues.material.emissive.b,
+    );
     this.emissiveIntensity = characterValues.material.emissiveIntensity;
     this.envMapIntensity = characterValues.material.envMapIntensity;
-    this.sheenColor = characterValues.material.sheenColor;
+    this.sheenColor = new Color().setRGB(
+      characterValues.material.sheenColor.r,
+      characterValues.material.sheenColor.g,
+      characterValues.material.sheenColor.b,
+    );
     this.sheen = characterValues.material.sheen;
     this.clearcoat = characterValues.material.clearcoat;
     this.clearcoatRoughness = characterValues.material.clearcoatRoughness;
@@ -141,12 +153,24 @@ export class CharacterMaterial extends MeshPhysicalMaterial {
     this.roughness = characterValues.material.roughness;
     this.ior = characterValues.material.ior;
     this.thickness = characterValues.material.thickness;
-    this.specularColor = characterValues.material.specularColor;
+    this.specularColor = new Color().setRGB(
+      characterValues.material.specularColor.r,
+      characterValues.material.specularColor.g,
+      characterValues.material.specularColor.b,
+    );
     this.specularIntensity = characterValues.material.specularIntensity;
-    this.emissive = characterValues.material.emissive;
+    this.emissive = new Color().setRGB(
+      characterValues.material.emissive.r,
+      characterValues.material.emissive.g,
+      characterValues.material.emissive.b,
+    );
     this.emissiveIntensity = characterValues.material.emissiveIntensity;
     this.envMapIntensity = characterValues.material.envMapIntensity;
-    this.sheenColor = characterValues.material.sheenColor;
+    this.sheenColor = new Color().setRGB(
+      characterValues.material.sheenColor.r,
+      characterValues.material.sheenColor.g,
+      characterValues.material.sheenColor.b,
+    );
     this.sheen = characterValues.material.sheen;
     this.clearcoat = characterValues.material.clearcoat;
     this.clearcoatRoughness = characterValues.material.clearcoatRoughness;

--- a/packages/3d-web-client-core/src/rendering/post-effects/bright-contrast-sat.ts
+++ b/packages/3d-web-client-core/src/rendering/post-effects/bright-contrast-sat.ts
@@ -1,0 +1,69 @@
+import { ShaderMaterial, Uniform } from "three";
+
+import { vertexShader } from "../shaders/vertex-shader";
+
+export const BrightnessContrastSaturation = new ShaderMaterial({
+  uniforms: {
+    tDiffuse: new Uniform(null),
+    brightness: new Uniform(0.0),
+    contrast: new Uniform(1.0),
+    saturation: new Uniform(1.0),
+  },
+  vertexShader: vertexShader,
+  fragmentShader: /* glsl */ `
+    precision highp float;
+    in vec2 vUv;
+
+    uniform sampler2D tDiffuse;
+    uniform float brightness;
+    uniform float contrast;
+    uniform float saturation;
+
+    mat4 brightnessMatrix(float brightness) {
+      return mat4(
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        brightness, brightness, brightness, 1
+      );
+    }
+
+    mat4 contrastMatrix(float contrast) {
+      float t = (1.0 - contrast) / 2.0;
+
+      return mat4(
+        contrast, 0, 0, 0,
+        0, contrast, 0, 0,
+        0, 0, contrast, 0,
+        t, t, t, 1
+      );
+    }
+
+    mat4 saturationMatrix(float saturation) {
+      vec3 luminance = vec3(0.3086, 0.6094, 0.0820);
+      float oneMinusSat = 1.0 - saturation;
+      vec3 red = vec3(luminance.x * oneMinusSat);
+      red += vec3(saturation, 0, 0);
+      vec3 green = vec3(luminance.y * oneMinusSat);
+      green += vec3(0, saturation, 0);
+      vec3 blue = vec3(luminance.z * oneMinusSat);
+      blue += vec3(0, 0, saturation);
+      return mat4(
+        red, 0,
+        green, 0,
+        blue, 0,
+        0, 0, 0, 1
+      );
+    }
+
+    void main(void) {
+      vec4 color = texture(tDiffuse, vUv);
+      gl_FragColor = (
+        brightnessMatrix(brightness) *
+        contrastMatrix(contrast) *
+        saturationMatrix(saturation) *
+        color
+      );
+    }
+  `,
+});

--- a/packages/3d-web-client-core/src/tweakpane/characterSettings.ts
+++ b/packages/3d-web-client-core/src/tweakpane/characterSettings.ts
@@ -1,5 +1,3 @@
-import { Color } from "three";
-
 export const characterValues = {
   material: {
     transmission: 1,
@@ -7,12 +5,12 @@ export const characterValues = {
     roughness: 0.12,
     ior: 1.5,
     thickness: 0.1,
-    specularColor: new Color(0xffffff),
+    specularColor: { r: 1.0, g: 1.0, b: 1.0 },
     specularIntensity: 0.1,
-    emissive: new Color(0xffffff),
+    emissive: { r: 1.0, g: 1.0, b: 1.0 },
     emissiveIntensity: 0.1,
     envMapIntensity: 1.0,
-    sheenColor: new Color(0xffffff),
+    sheenColor: { r: 1.0, g: 1.0, b: 1.0 },
     sheen: 0.5,
     clearcoat: 0.0,
     clearcoatRoughness: 0.0,

--- a/packages/3d-web-client-core/src/tweakpane/composerSettings.ts
+++ b/packages/3d-web-client-core/src/tweakpane/composerSettings.ts
@@ -1,12 +1,11 @@
 import { BlendFunction, ToneMappingMode } from "postprocessing";
-import { Color } from "three";
 
 export const composerValues = {
   renderer: {
     shadowMap: 2,
-    toneMapping: 5,
-    exposure: 0.95,
-    bgIntensity: 0.5,
+    toneMapping: 4,
+    exposure: 1,
+    bgIntensity: 0.6,
     bgBlurriness: 0.0,
   },
   ssao: {
@@ -17,11 +16,11 @@ export const composerValues = {
     rings: 7,
     luminanceInfluence: 0.7,
     radius: 0.03,
-    intensity: 2.1,
+    intensity: 2.5,
     bias: 0.05,
     fade: 0.03,
-    resolutionScale: 0.5,
-    color: new Color(0x000000),
+    resolutionScale: 0.75,
+    color: { r: 0, g: 0, b: 0 },
     worldDistanceThreshold: 30,
     worldDistanceFalloff: 7,
     worldProximityThreshold: 0.5,
@@ -36,19 +35,18 @@ export const composerValues = {
     averageLuminance: 0.01,
     adaptationRate: 2.0,
   },
-  brightness: 0.0,
-  contrast: 0.0,
-  hue: 0.0,
-  saturation: -0.05,
-  grain: 0.05,
-  bloom: 0.5,
+  brightness: -0.03,
+  contrast: 1.3,
+  saturation: 0.95,
+  grain: 0.055,
+  bloom: 0.4,
 };
 
 export const composerOptions = {
   renderer: {
     shadowMap: { min: 0, max: 2, step: 1 },
     toneMapping: { min: 0, max: 5, step: 1 },
-    exposure: { min: 0, max: 1, step: 0.01 },
+    exposure: { min: 0, max: 3, step: 0.01 },
     bgIntensity: { min: 0, max: 1, step: 0.01 },
     bgBlurriness: { min: 0, max: 0.1, step: 0.001 },
   },
@@ -79,13 +77,10 @@ export const composerOptions = {
     amount: { min: -1.0, max: 1.0, step: 0.01 },
   },
   contrast: {
-    amount: { min: -1.0, max: 1.0, step: 0.01 },
-  },
-  hue: {
-    amount: { min: 0.0, max: Math.PI * 2.0, step: 0.001 },
+    amount: { min: 0.0, max: 2.0, step: 0.01 },
   },
   saturation: {
-    amount: { min: -1.0, max: 1.0, step: 0.01 },
+    amount: { min: 0.0, max: 2.0, step: 0.01 },
   },
   grain: {
     amount: { min: 0, max: 0.2, step: 0.002 },


### PR DESCRIPTION
This PR fixes the brightness and contrast step of the post-processing chain and applies the minor fixes/improvements listed below:
- Tweakpane import/export now works appropriately for color properties (export was broken for those before). The folder also shows in an adequate position now as it's a global setting exporter and not specific to the renderer;
- Exposure values now can be set above 1;
- Custom tone mapping Tweakpane folder will now show for renderer tone mapping 0 (no tone mapping) and 5 (custom tone mapping);
- Tweakpane visibility toggle now saves to localStorage to prevent having to re-open/close after refreshing the page.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)

![Screenshot 2023-07-31 at 12 46 48](https://github.com/mml-io/3d-web-experience/assets/33723163/dda86db2-ac94-4c6f-9f8b-72df16f654b0)
