### PR TITLE
fixes first-person camera #14

### DIFF
--- a/packages/3d-web-client-core/src/camera/CameraManager.ts
+++ b/packages/3d-web-client-core/src/camera/CameraManager.ts
@@ -14,7 +14,7 @@ export class CameraManager {
 
   private initialFOV: number = 80;
   private fov: number = this.initialFOV;
-  private minFOV: number = 65;
+  private minFOV: number = 63;
   private maxFOV: number = 85;
   private targetFOV: number = this.initialFOV;
 
@@ -23,7 +23,7 @@ export class CameraManager {
 
   private dampingFactor: number = 0.091;
 
-  private targetDistance: number = this.initialDistance;
+  public targetDistance: number = this.initialDistance;
   private distance: number = this.initialDistance;
 
   private targetPhi: number | null = Math.PI / 2;

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -3,7 +3,7 @@ import { Camera, Group, Object3D, PerspectiveCamera, Vector3 } from "three";
 
 import { CameraManager } from "../camera/CameraManager";
 import { CollisionsManager } from "../collisions/CollisionsManager";
-import { getSpawnPositionInsideCircle } from "../helpers/math-helpers";
+import { ease, getSpawnPositionInsideCircle } from "../helpers/math-helpers";
 import { KeyInputManager } from "../input/KeyInputManager";
 import { TimeManager } from "../time/TimeManager";
 
@@ -43,6 +43,9 @@ export class CharacterManager {
 
   private characterDescription: CharacterDescription | null = null;
   public character: Character | null = null;
+
+  private cameraOffsetTarget: number = 0;
+  private cameraOffset: number = 0;
 
   public readonly group: Group;
 
@@ -176,7 +179,14 @@ export class CharacterManager {
   public update() {
     if (this.character) {
       this.character.update(this.timeManager.time);
-      this.cameraManager.setTarget(this.character.position.add(new Vector3(0, 1.3, 0)));
+
+      if (this.character.model?.mesh) {
+        this.cameraOffsetTarget = this.cameraManager.targetDistance <= 0.4 ? 0.6 : 0;
+        this.cameraOffset += ease(this.cameraOffsetTarget, this.cameraOffset, 0.1);
+        const targetOffset = new Vector3(0, 1.3, this.cameraOffset);
+        targetOffset.applyQuaternion(this.character.model.mesh.quaternion);
+        this.cameraManager.setTarget(this.character.position.add(targetOffset));
+      }
 
       if (this.character.controller) {
         this.character.controller.update();

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -153,7 +153,7 @@ export class LocalController {
   private updateAzimuthalAngle(): void {
     if (!this.thirdPersonCamera || !this.model?.mesh) return;
     const camToModelDistance = this.thirdPersonCamera.position.distanceTo(this.model.mesh.position);
-    const isCameraFirstPerson = camToModelDistance < 1.5;
+    const isCameraFirstPerson = camToModelDistance < 2;
     if (isCameraFirstPerson) {
       const cameraForward = new Vector3(0, 0, 1).applyQuaternion(this.thirdPersonCamera.quaternion);
       this.azimuthalAngle = Math.atan2(cameraForward.x, cameraForward.z);

--- a/packages/3d-web-client-core/src/rendering/composer.ts
+++ b/packages/3d-web-client-core/src/rendering/composer.ts
@@ -6,7 +6,6 @@ import {
   ShaderPass,
   BloomEffect,
   SSAOEffect,
-  NormalPass,
   BlendFunction,
   TextureEffect,
   ToneMappingEffect,
@@ -14,9 +13,11 @@ import {
   SMAAPreset,
   EdgeDetectionMode,
   PredicationMode,
+  NormalPass,
 } from "postprocessing";
 import {
   Color,
+  HalfFloatType,
   LinearSRGBColorSpace,
   LoadingManager,
   PMREMGenerator,
@@ -90,7 +91,9 @@ export class Composer {
 
     document.body.appendChild(this.renderer.domElement);
 
-    this.composer = new EffectComposer(this.renderer);
+    this.composer = new EffectComposer(this.renderer, {
+      frameBufferType: HalfFloatType,
+    });
 
     this.tweakPane = new TweakPane(this.renderer, this.scene, this.composer);
 

--- a/packages/3d-web-client-core/src/rendering/post-effects/bright-contrast-sat.ts
+++ b/packages/3d-web-client-core/src/rendering/post-effects/bright-contrast-sat.ts
@@ -66,4 +66,5 @@ export const BrightnessContrastSaturation = new ShaderMaterial({
       );
     }
   `,
+  dithering: true,
 });

--- a/packages/3d-web-client-core/src/rendering/post-effects/gauss-grain.ts
+++ b/packages/3d-web-client-core/src/rendering/post-effects/gauss-grain.ts
@@ -33,7 +33,7 @@ export const GaussGrainEffect = new ShaderMaterial({
     }
 
     vec3 gaussgrain() {
-      vec2 ps = vec2(1.01) / resolution.xy;
+      vec2 ps = vec2(1.0) / resolution.xy;
       vec2 uv = gl_FragCoord.xy * ps;
       float t = time;
       float seed = dot(uv, vec2(12.9898, 78.233));
@@ -50,4 +50,5 @@ export const GaussGrainEffect = new ShaderMaterial({
       gl_FragColor = vec4(clamp(col, 0.0, 1.0), alpha);
     }
   `,
+  dithering: true,
 });


### PR DESCRIPTION
This PR Resolves #14 

It introduces changes to the `CharacterManager` to set the proper camera targeting behavior to prevent the visual bug caused by our ambient occlusion when in 1st person mode.

This PR also fixes some minor banding issues (before/after can be seen in the screenshots below) caused by the former float type used by the post-processing chain.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)


![Screenshot 2023-08-02 at 14 12 24](https://github.com/mml-io/3d-web-experience/assets/33723163/586f810d-f774-48da-ac19-07e3a9d88956)


![Screenshot 2023-08-02 at 11 11 03](https://github.com/mml-io/3d-web-experience/assets/33723163/e97eb9f3-f3fe-4dcc-a7af-38563c75c1e2)
