### PR TITLE
fixes tweakpane to allow disabling of custom tone mapping

### DIFF
--- a/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
+++ b/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
@@ -246,12 +246,8 @@ export class TweakPane {
           break;
         case "toneMapping":
           this.renderer.toneMapping = e.value;
-          if (e.value !== 5 && e.value !== 0) {
-            this.toneMapping.hidden = true;
-          } else {
-            this.toneMapping.hidden = false;
-          }
-          toneMappingPass.enabled = e.value === 5 || e.value === 0 ? true : false;
+          this.toneMapping.hidden = e.value !== 5;
+          toneMappingPass.enabled = e.value === 5 ? true : false;
           setToneMappingType(e.value);
           break;
         case "exposure":

--- a/packages/3d-web-client-core/src/tweakpane/composerSettings.ts
+++ b/packages/3d-web-client-core/src/tweakpane/composerSettings.ts
@@ -3,9 +3,9 @@ import { BlendFunction, ToneMappingMode } from "postprocessing";
 export const composerValues = {
   renderer: {
     shadowMap: 2,
-    toneMapping: 4,
+    toneMapping: 5,
     exposure: 1,
-    bgIntensity: 0.6,
+    bgIntensity: 0.5,
     bgBlurriness: 0.0,
   },
   ssao: {
@@ -37,9 +37,9 @@ export const composerValues = {
   },
   brightness: -0.03,
   contrast: 1.3,
-  saturation: 0.95,
-  grain: 0.055,
-  bloom: 0.4,
+  saturation: 0.91,
+  grain: 0.061,
+  bloom: 0.45,
 };
 
 export const composerOptions = {
@@ -86,7 +86,7 @@ export const composerOptions = {
     amount: { min: 0, max: 0.2, step: 0.002 },
   },
   bloom: {
-    amount: { min: 0, max: 4, step: 0.1 },
+    amount: { min: 0, max: 2, step: 0.05 },
   },
 };
 


### PR DESCRIPTION
Resolves #26 

This PR fixes an improper setting on TweakPane that was preventing the user from completely disabling the custom tone mapping.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] The title references the corresponding issue # (if relevant)
