### PR TITLE
fixes default transform properties composed with invalid quaternions

### DIFF
--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -58,7 +58,6 @@ export class CharacterManager {
     private readonly sendUpdate: (update: CharacterState) => void,
   ) {
     this.group = new Group();
-    setInterval(() => this.update.bind(this), 3000);
   }
 
   /* TODO: 
@@ -97,7 +96,7 @@ export class CharacterManager {
                 y: spawnPosition.y,
                 z: spawnPosition.z,
               },
-              rotation: { quaternionY: 0, quaternionW: 0 },
+              rotation: { quaternionY: 0, quaternionW: 1 },
               state: AnimationState.idle,
             });
           }

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -58,12 +58,7 @@ export class LocalController {
   private speed: number = 0;
   private targetSpeed: number = 0;
 
-  public networkState: CharacterState = {
-    id: 0,
-    position: { x: 0, y: 0, z: 0 },
-    rotation: { quaternionY: 0, quaternionW: 0 },
-    state: AnimationState.idle,
-  };
+  public networkState: CharacterState;
 
   constructor(
     private readonly model: CharacterModel,
@@ -73,7 +68,12 @@ export class LocalController {
     private readonly cameraManager: CameraManager,
     private readonly timeManager: TimeManager,
   ) {
-    setInterval(() => this.update.bind(this), 3000);
+    this.networkState = {
+      id: this.id,
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { quaternionY: 0, quaternionW: 1 },
+      state: AnimationState.idle,
+    };
   }
 
   public update(): void {
@@ -287,19 +287,27 @@ export class LocalController {
   }
 
   private updateNetworkState(): void {
-    if (!this.model?.mesh) return;
-    const characterQuaternion = this.model.mesh.getWorldQuaternion(new Quaternion());
-    const positionUpdate = new Vector3(
-      this.model.mesh.position.x,
-      this.model.mesh.position.y,
-      this.model.mesh.position.z,
-    );
-    this.networkState = {
-      id: this.id,
-      position: positionUpdate,
-      rotation: { quaternionY: characterQuaternion?.y, quaternionW: characterQuaternion?.w },
-      state: this.model.currentAnimation as AnimationState,
-    };
+    if (!this.model?.mesh) {
+      this.networkState = {
+        id: this.id,
+        position: new Vector3(),
+        rotation: { quaternionY: 0, quaternionW: 1 },
+        state: AnimationState.idle as AnimationState,
+      };
+    } else {
+      const characterQuaternion = this.model.mesh.getWorldQuaternion(new Quaternion());
+      const positionUpdate = new Vector3(
+        this.model.mesh.position.x,
+        this.model.mesh.position.y,
+        this.model.mesh.position.z,
+      );
+      this.networkState = {
+        id: this.id,
+        position: positionUpdate,
+        rotation: { quaternionY: characterQuaternion.y, quaternionW: characterQuaternion.w },
+        state: this.model.currentAnimation as AnimationState,
+      };
+    }
   }
 
   private resetPosition(): void {

--- a/packages/3d-web-client-core/src/character/RemoteController.ts
+++ b/packages/3d-web-client-core/src/character/RemoteController.ts
@@ -20,17 +20,18 @@ export class RemoteController {
   private animations = new Map<AnimationState, AnimationAction>();
   public currentAnimation: AnimationState = AnimationState.idle;
 
-  public networkState: CharacterState = {
-    id: 0,
-    position: { x: 0, y: 0, z: 0 },
-    rotation: { quaternionY: 0, quaternionW: 0 },
-    state: this.currentAnimation as AnimationState,
-  };
+  public networkState: CharacterState;
 
   constructor(public readonly character: Character, public readonly id: number) {
     this.characterModel = this.character.model!.mesh!;
     this.characterModel.updateMatrixWorld();
     this.animationMixer = new AnimationMixer(this.characterModel);
+    this.networkState = {
+      id: this.id,
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { quaternionY: 0, quaternionW: 1 },
+      state: this.currentAnimation as AnimationState,
+    };
   }
 
   public update(clientUpdate: CharacterState, time: number, deltaTime: number): void {

--- a/packages/3d-web-user-networking/src/UserNetworkingServer.ts
+++ b/packages/3d-web-user-networking/src/UserNetworkingServer.ts
@@ -89,7 +89,7 @@ export class UserNetworkingServer {
       update: {
         id,
         position: { x: 0, y: 0, z: 0 },
-        rotation: { quaternionY: 0, quaternionW: 0 },
+        rotation: { quaternionY: 0, quaternionW: 1 },
         state: 0,
       },
     });


### PR DESCRIPTION
This PR fixes multiple occurrences of default transform properties being set with invalid quaternions (all components, including the scalar `w` component being zero).

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
