### PR TITLE
implements visual speaking indicators for the 3d-web-voice-chat package

### DIFF
--- a/example/web-client/src/index.ts
+++ b/example/web-client/src/index.ts
@@ -120,6 +120,7 @@ export class App {
     );
 
     this.characterManager = new CharacterManager(
+      this.composer,
       this.collisionsManager,
       this.cameraManager,
       this.timeManager,
@@ -205,6 +206,9 @@ export class App {
   public update(): void {
     this.timeManager.update();
     this.characterManager.update();
+    this.voiceChatManager?.speakingParticipants.forEach((value: boolean, id: number) => {
+      this.characterManager.setSpeakingCharacter(id, value);
+    });
     this.cameraManager.update();
     if (this.sun) {
       this.sun.updateCharacterPosition(this.characterManager.character?.position);

--- a/packages/3d-web-client-core/src/character/Character.ts
+++ b/packages/3d-web-client-core/src/character/Character.ts
@@ -3,9 +3,11 @@ import { Color, Vector3 } from "three";
 import { CameraManager } from "../camera/CameraManager";
 import { CollisionsManager } from "../collisions/CollisionsManager";
 import { KeyInputManager } from "../input/KeyInputManager";
+import { Composer } from "../rendering/composer";
 import { TimeManager } from "../time/TimeManager";
 
 import { CharacterModel } from "./CharacterModel";
+import { CharacterSpeakingIndicator } from "./CharacterSpeakingIndicator";
 import { CharacterTooltip } from "./CharacterTooltip";
 import { LocalController } from "./LocalController";
 
@@ -28,6 +30,7 @@ export class Character {
   public position: Vector3 = new Vector3();
 
   public tooltip: CharacterTooltip | null = null;
+  public speakingIndicator: CharacterSpeakingIndicator | null = null;
 
   constructor(
     private readonly characterDescription: CharacterDescription,
@@ -38,6 +41,7 @@ export class Character {
     private readonly keyInputManager: KeyInputManager,
     private readonly cameraManager: CameraManager,
     private readonly timeManager: TimeManager,
+    private readonly composer: Composer,
   ) {
     this.load();
   }
@@ -47,6 +51,9 @@ export class Character {
     await this.model.init();
     if (this.tooltip === null) {
       this.tooltip = new CharacterTooltip(this.model.mesh!);
+    }
+    if (this.speakingIndicator === null) {
+      this.speakingIndicator = new CharacterSpeakingIndicator(this.composer.postPostScene);
     }
     this.color = this.model.material.colorsCube216[this.id];
     if (this.isLocal) {
@@ -66,6 +73,15 @@ export class Character {
     if (!this.model) return;
     if (this.tooltip) {
       this.tooltip.update(this.cameraManager.camera);
+    }
+    if (this.speakingIndicator) {
+      this.speakingIndicator.setTime(time);
+      if (this.model.mesh && this.model.headBone) {
+        this.speakingIndicator.setBillboarding(
+          this.model.headBone?.getWorldPosition(new Vector3()),
+          this.cameraManager.camera,
+        );
+      }
     }
     this.model.mesh!.getWorldPosition(this.position);
     if (typeof this.model.material.uniforms.time !== "undefined") {

--- a/packages/3d-web-client-core/src/character/CharacterModel.ts
+++ b/packages/3d-web-client-core/src/character/CharacterModel.ts
@@ -2,6 +2,7 @@ import {
   AnimationAction,
   AnimationClip,
   AnimationMixer,
+  Bone,
   LoopRepeat,
   Mesh,
   MeshStandardMaterial,
@@ -19,6 +20,7 @@ export class CharacterModel {
 
   public mesh: Object3D | null = null;
   public material: CharacterMaterial = new CharacterMaterial();
+  public headBone: Bone | null = null;
 
   public animations: Record<string, AnimationAction> = {};
   public animationMixer: AnimationMixer | null = null;
@@ -57,6 +59,9 @@ export class CharacterModel {
   public hideMaterialByMeshName(meshName: any): void {
     if (!this.mesh) return;
     this.mesh.traverse((child: Object3D) => {
+      if (child.type === "Bone" && child.name === "mixamorigHeadTop_End") {
+        this.headBone = child as Bone;
+      }
       if (child.type === "SkinnedMesh" && child.name === meshName) {
         (child as Mesh).material = new MeshStandardMaterial({
           color: 0xff0000,

--- a/packages/3d-web-client-core/src/character/CharacterSpeakingIndicator.ts
+++ b/packages/3d-web-client-core/src/character/CharacterSpeakingIndicator.ts
@@ -1,0 +1,103 @@
+import {
+  Camera,
+  CircleGeometry,
+  GLSL3,
+  Mesh,
+  Object3D,
+  RawShaderMaterial,
+  Scene,
+  Vector3,
+} from "three";
+
+import { ease } from "../helpers/math-helpers";
+
+export class CharacterSpeakingIndicator {
+  private vertexShader = /* glsl */ `
+  in vec3 position;
+  in vec2 uv;
+  uniform mat4 modelViewMatrix;
+  uniform mat4 projectionMatrix;
+  out vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }`;
+
+  private fragmentShader = /* glsl */ `
+  precision highp float;
+
+  uniform float time;
+  uniform float alpha;
+  in vec2 vUv;
+  out vec4 fragColor;
+
+  const float size = 1.7;
+  const float distribution = 0.03;
+  const float speed = 0.2;
+  const float overdraw = 3.5;
+  const float shapeK = 0.25;
+
+  float sdHyperbola(vec2 p, float k, float wi) {
+    p = abs(p);
+    float k2 = k * k;
+    float a = p.x + p.y;
+    float i = 0.5 * (a - k2 / a) > wi ? -1.0 : 1.0;
+    float x = clamp(0.5 * (a - k2 / a), 0.0, wi);
+    vec2 q = vec2(x, sqrt(x * x + k2));
+    float s = sign(p.x * p.x - p.y * p.y + k2);
+    return s * length(p - q);
+  }
+
+  void main(void) {
+    vec2 uv = (vUv * 2.0 - 1.0);
+    float r = -(uv.x * uv.x + uv.y * uv.y);
+    float z = 0.5 + 0.5 * sin((r + time * speed) / distribution);
+    float a = clamp(smoothstep(-0.1, 0.2, size - length(uv * 2.0)), 0.0, 0.5);
+    float h = clamp(sdHyperbola(uv, shapeK, 1.0), 0.0, 1.0) * overdraw;
+    float fragAlpha = clamp(a * h, 0.0, 0.7);
+    fragColor = vec4(z * fragAlpha) * alpha;
+  }`;
+
+  private uniforms = {
+    time: { value: 0.0 },
+    alpha: { value: 0.0 },
+  };
+
+  private geometry: CircleGeometry = new CircleGeometry(0.35, 21);
+  private material: RawShaderMaterial = new RawShaderMaterial({
+    vertexShader: this.vertexShader,
+    fragmentShader: this.fragmentShader,
+    uniforms: this.uniforms,
+    transparent: true,
+    glslVersion: GLSL3,
+  });
+  private mesh = new Mesh(this.geometry, this.material);
+
+  private currentAlpha = 0.0;
+  private targetAlpha = 0.0;
+
+  constructor(private scene: Scene | Object3D) {
+    this.scene.add(this.mesh);
+  }
+
+  public setBillboarding(position: Vector3, camera: Camera) {
+    this.mesh.position.set(position.x, position.y - 0.15, position.z);
+    this.mesh.lookAt(camera.position);
+  }
+
+  public setTime(value: number) {
+    this.currentAlpha += ease(this.targetAlpha, this.currentAlpha, 0.06);
+    this.uniforms.time.value = value;
+    this.uniforms.alpha.value = this.currentAlpha;
+  }
+
+  public setSpeaking(value: boolean) {
+    this.targetAlpha = value === true ? 1.0 : 0.0;
+  }
+
+  public dispose() {
+    this.scene.remove(this.mesh);
+    this.mesh.material.dispose();
+    this.mesh.geometry.dispose();
+  }
+}

--- a/packages/3d-web-client-core/src/helpers/math-helpers.ts
+++ b/packages/3d-web-client-core/src/helpers/math-helpers.ts
@@ -1,4 +1,23 @@
-import { Vector3 } from "three";
+import { Quaternion, Vector3, Vector4 } from "three";
+
+export const roundToDecimalPlaces = (value: number, decimalPlaces: number): number => {
+  const mult = 10 ** decimalPlaces;
+  return Math.round(value * mult) / mult;
+};
+
+export const toArray = (
+  origin: Vector3 | Vector4 | Quaternion,
+  precision: number = 3,
+): number[] => {
+  const array = [];
+  array[0] = roundToDecimalPlaces(origin.x, precision);
+  array[1] = roundToDecimalPlaces(origin.y, precision);
+  array[2] = roundToDecimalPlaces(origin.z, precision);
+  if (origin instanceof Vector4 || origin instanceof Quaternion) {
+    array[3] = roundToDecimalPlaces(origin.w, precision);
+  }
+  return array;
+};
 
 export const getSpawnPositionInsideCircle = (
   radius: number,

--- a/packages/3d-web-client-core/src/rendering/composer.ts
+++ b/packages/3d-web-client-core/src/rendering/composer.ts
@@ -56,6 +56,7 @@ export class Composer {
   private isEnvHDRI: boolean = false;
 
   private readonly scene: Scene;
+  public postPostScene: Scene;
   private readonly camera: PerspectiveCamera;
   public readonly renderer: WebGLRenderer;
 
@@ -93,6 +94,7 @@ export class Composer {
 
   constructor(scene: Scene, camera: PerspectiveCamera, spawnSun: boolean = false) {
     this.scene = scene;
+    this.postPostScene = new Scene();
     this.camera = camera;
     this.spawnSun = spawnSun;
     this.renderer = new WebGLRenderer({
@@ -271,6 +273,7 @@ export class Composer {
     this.gaussGrainEffect.uniforms.time.value = timeManager.time;
     this.gaussGrainEffect.uniforms.alpha.value = 1.0;
     this.composer.render();
+    this.renderer.render(this.postPostScene, this.camera);
 
     if (this.tweakPane.guiVisible) {
       this.tweakPane.updateStats(timeManager);

--- a/packages/3d-web-voice-chat/src/voice-chat-manager/VoiceChatManager.ts
+++ b/packages/3d-web-voice-chat/src/voice-chat-manager/VoiceChatManager.ts
@@ -58,6 +58,8 @@ export class VoiceChatManager {
   private participants = new Map<string, string>();
   private activeSpeakers: number = 0;
 
+  public speakingParticipants = new Map<number, boolean>();
+
   private voiceChatUI: VoiceChatUI;
 
   private conference: Conference | null = null;
@@ -101,6 +103,11 @@ export class VoiceChatManager {
       for (const [, participant] of VoxeetSDK.conference.participants) {
         const parsed = parseInt(participant.info.name!, 10);
         if (!parsed) break;
+        // eslint-disable-next-line @typescript-eslint/no-loop-func
+        VoxeetSDK.conference.isSpeaking(participant, (value: boolean) => {
+          this.speakingParticipants.set(parsed, value);
+        });
+
         if (participant.status === "Connected" && participant.audioTransmitting === true) {
           activeSpeakers++;
         }
@@ -277,7 +284,7 @@ export class VoiceChatManager {
         params: {
           audioOnly: true,
           dolbyVoice: true,
-          liveRecording: true,
+          liveRecording: false,
           spatialAudioStyle: "individual" as SpatialAudioStyle,
           stats: true,
           ttl: 0,


### PR DESCRIPTION
This PR implements speaking indicators for the `3d-web-voice-chat` package.

To achieve this through a plane attached to the character that renders an animated fragment shader, this PR also implements an extra scene for the `composer` so we can have objects being rendered while unaffected by the post-processing chain.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)

![Screenshot 2023-09-25 at 13 32 03](https://github.com/mml-io/3d-web-experience/assets/33723163/2d75e269-7985-413e-a302-5fdf70e51343)
