### PR TITLE
User avatar sticks to moving surfaces (#91)

### DIFF
--- a/packages/3d-web-client-core/src/camera/CameraManager.ts
+++ b/packages/3d-web-client-core/src/camera/CameraManager.ts
@@ -145,11 +145,11 @@ export class CameraManager {
       this.camera.position,
       this.target.clone().sub(this.camera.position).normalize(),
     );
-    const minimumDistance = this.collisionsManager.raycastFirstDistance(this.rayCaster.ray);
+    const firstRaycastHit = this.collisionsManager.raycastFirst(this.rayCaster.ray);
     const cameraToPlayerDistance = this.camera.position.distanceTo(this.target);
 
-    if (minimumDistance !== null && minimumDistance <= cameraToPlayerDistance) {
-      this.targetDistance = cameraToPlayerDistance - minimumDistance;
+    if (firstRaycastHit !== null && firstRaycastHit[0] <= cameraToPlayerDistance) {
+      this.targetDistance = cameraToPlayerDistance - firstRaycastHit[0];
       this.distance = this.targetDistance;
     } else {
       this.targetDistance += (this.desiredDistance - this.targetDistance) * this.dampingFactor * 4;

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -142,17 +142,17 @@ export class CharacterManager {
         this.localCharacter.speakingIndicator?.setSpeaking(this.speakingCharacters.get(this.id)!);
       }
 
+      this.localController.update();
+      if (this.timeManager.frame % 2 === 0) {
+        this.sendUpdate(this.localController.networkState);
+      }
+
       this.cameraOffsetTarget = this.cameraManager.targetDistance <= 0.4 ? 0.13 : 0;
       this.cameraOffset += ease(this.cameraOffsetTarget, this.cameraOffset, 0.1);
       const targetOffset = new Vector3(0, 0, this.cameraOffset);
       targetOffset.add(this.headTargetOffset);
       targetOffset.applyQuaternion(this.localCharacter.quaternion);
       this.cameraManager.setTarget(targetOffset.add(this.localCharacter.position));
-
-      this.localController.update();
-      if (this.timeManager.frame % 2 === 0) {
-        this.sendUpdate(this.localController.networkState);
-      }
 
       for (const [id, update] of this.clientStates) {
         if (this.remoteCharacters.has(id) && this.speakingCharacters.has(id)) {


### PR DESCRIPTION
Resolves #91

This PR adds support for standing on moving surfaces. This is achieved by raycasting downwards from the user avatar, detecting the element below it, and then applying the movement of that element to the user in the next tick.

https://github.com/mml-io/3d-web-experience/assets/669895/8d7345fe-09de-4acd-b8d1-ea3fe1956397

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature

**Does your PR fulfill the following requirements?**

- [x] The title references the corresponding issue # (if relevant)


