### PR TITLE
Refactor mml character loading

### DIFF
--- a/example/local-multi-web-client/src/LocalAvatarClient.ts
+++ b/example/local-multi-web-client/src/LocalAvatarClient.ts
@@ -1,4 +1,5 @@
 import {
+  AnimationConfig,
   CameraManager,
   CharacterDescription,
   CharacterManager,
@@ -19,18 +20,26 @@ import airAnimationFileUrl from "../../assets/models/anim_air.glb";
 import idleAnimationFileUrl from "../../assets/models/anim_idle.glb";
 import jogAnimationFileUrl from "../../assets/models/anim_jog.glb";
 import sprintAnimationFileUrl from "../../assets/models/anim_run.glb";
-import meshFileUrl from "../../assets/models/bot.glb";
+import defaultAvatarMeshFileUrl from "../../assets/models/bot.glb";
 
 import { LocalAvatarServer } from "./LocalAvatarServer";
 import { Room } from "./Room";
 
-const characterDescription: CharacterDescription = {
+const animationConfig: AnimationConfig = {
   airAnimationFileUrl,
   idleAnimationFileUrl,
   jogAnimationFileUrl,
-  meshFileUrl,
   sprintAnimationFileUrl,
-  modelScale: 1,
+};
+
+// Specify the avatar to use here:
+const characterDescription: CharacterDescription = {
+  // Option 1 (Default) - Use a GLB file directly
+  meshFileUrl: defaultAvatarMeshFileUrl, // This is just an address of a GLB file
+  // Option 2 - Use an MML Character from a URL
+  // mmlCharacterUrl: "https://...",
+  // Option 3 - Use an MML Character from a string
+  // mmlCharacterString: `<m-character src="https://..."></m-character>`,
 };
 
 export class LocalAvatarClient {
@@ -111,6 +120,8 @@ export class LocalAvatarClient {
       (characterState: CharacterState) => {
         localAvatarServer.send(localClientId, characterState);
       },
+      animationConfig,
+      characterDescription,
     );
     this.scene.add(this.characterManager.group);
 
@@ -132,7 +143,7 @@ export class LocalAvatarClient {
     this.scene.add(room);
 
     this.characterManager.spawnLocalCharacter(
-      characterDescription!,
+      characterDescription,
       localClientId,
       spawnPosition,
       spawnRotation,

--- a/example/web-client/src/index.ts
+++ b/example/web-client/src/index.ts
@@ -12,6 +12,7 @@ import {
   MMLCompositionScene,
   TimeManager,
   TweakPane,
+  AnimationConfig,
 } from "@mml-io/3d-web-client-core";
 import { ChatNetworkingClient, FromClientChatMessage, TextChatUI } from "@mml-io/3d-web-text-chat";
 import {
@@ -33,18 +34,26 @@ import airAnimationFileUrl from "../../assets/models/anim_air.glb";
 import idleAnimationFileUrl from "../../assets/models/anim_idle.glb";
 import jogAnimationFileUrl from "../../assets/models/anim_jog.glb";
 import sprintAnimationFileUrl from "../../assets/models/anim_run.glb";
-import meshFileUrl from "../../assets/models/bot.glb";
+import defaultAvatarMeshFileUrl from "../../assets/models/bot.glb";
 
 import { LoadingScreen } from "./LoadingScreen";
 import { Room } from "./Room";
 
-const characterDescription: CharacterDescription = {
+const animationConfig: AnimationConfig = {
   airAnimationFileUrl,
   idleAnimationFileUrl,
   jogAnimationFileUrl,
-  meshFileUrl,
   sprintAnimationFileUrl,
-  modelScale: 1,
+};
+
+// Specify the avatar to use here:
+const characterDescription: CharacterDescription = {
+  // Option 1 (Default) - Use a GLB file directly
+  meshFileUrl: defaultAvatarMeshFileUrl, // This is just an address of a GLB file
+  // Option 2 - Use an MML Character from a URL
+  // mmlCharacterUrl: "https://...",
+  // Option 3 - Use an MML Character from a string
+  // mmlCharacterString: `<m-character src="https://..."></m-character>`,
 };
 
 const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -157,19 +166,8 @@ export class App {
         this.latestCharacterObject.characterState = characterState;
         this.networkClient.sendUpdate(characterState);
       },
-      /*
-      If you want to use an MML Character in the experience, this is where you should
-      pass it as an argument.
-
-      MML Characters can be loaded by passing a URL that can be fetched and serve your
-      <m-character> tag, or just by passing your MML Character description in a string
-      like in the example below:
-      
-      `
-      <m-character src="../../assets/models/bot.glb">
-      </m-character>
-      `,
-      */
+      animationConfig,
+      characterDescription,
     );
     this.scene.add(this.characterManager.group);
 

--- a/packages/3d-web-client-core/src/character/Character.ts
+++ b/packages/3d-web-client-core/src/character/Character.ts
@@ -9,14 +9,17 @@ import { CharacterSpeakingIndicator } from "./CharacterSpeakingIndicator";
 import { AnimationState } from "./CharacterState";
 import { CharacterTooltip } from "./CharacterTooltip";
 
-export type CharacterDescription = {
-  meshFileUrl: string;
+export type AnimationConfig = {
   idleAnimationFileUrl: string;
   jogAnimationFileUrl: string;
   sprintAnimationFileUrl: string;
   airAnimationFileUrl: string;
-  modelScale: number;
-  meshModel?: Object3D;
+};
+
+export type CharacterDescription = {
+  meshFileUrl?: string;
+  mmlCharacterUrl?: string;
+  mmlCharacterString?: string;
 };
 
 export class Character extends Group {
@@ -27,6 +30,7 @@ export class Character extends Group {
 
   constructor(
     private readonly characterDescription: CharacterDescription,
+    private readonly animationConfig: AnimationConfig,
     private readonly characterModelLoader: CharacterModelLoader,
     private readonly characterId: number,
     private readonly modelLoadedCallback: () => void,
@@ -40,7 +44,11 @@ export class Character extends Group {
   }
 
   private async load(): Promise<void> {
-    this.model = new CharacterModel(this.characterDescription, this.characterModelLoader);
+    this.model = new CharacterModel(
+      this.characterDescription,
+      this.animationConfig,
+      this.characterModelLoader,
+    );
     await this.model.init();
     this.add(this.model.mesh!);
     if (this.speakingIndicator === null) {

--- a/packages/3d-web-client-core/src/character/CharacterModelLoader.ts
+++ b/packages/3d-web-client-core/src/character/CharacterModelLoader.ts
@@ -85,6 +85,8 @@ export class CharacterModelLoader {
     this.modelCache = new LRUCache(maxCacheSize);
   }
 
+  async load(fileUrl: string, fileType: "model"): Promise<Object3D | undefined>;
+  async load(fileUrl: string, fileType: "animation"): Promise<AnimationClip | undefined>;
   async load(
     fileUrl: string,
     fileType: "model" | "animation",

--- a/packages/3d-web-client-core/src/index.ts
+++ b/packages/3d-web-client-core/src/index.ts
@@ -1,5 +1,5 @@
 export { CameraManager } from "./camera/CameraManager";
-export { CharacterDescription } from "./character/Character";
+export { CharacterDescription, AnimationConfig } from "./character/Character";
 export { CharacterManager } from "./character/CharacterManager";
 export * from "./character/url-position";
 export * from "./helpers/math-helpers";


### PR DESCRIPTION
This PR refactors how and where the character loading (from either mesh GLB or MML url / string) takes place.

This:
* Avoids a race condition where the character would not be created until the loading had completed, and (an extremely unlikely) race condition that the remote character would attempt to use the characterDescription before it had been augmented by the local loading
* Makes it clearer how to implement per-user character descriptions

**What kind of change does your PR introduce?** (check at least one)

- [x] Refactor