### PR TITLE
Feature/avatar animation cleanup

### DIFF
--- a/example/assets/avatar/anims/idle.glb
+++ b/example/assets/avatar/anims/idle.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e423960b9b17b2c11c4d23c558bc08a1ff529d0453447a455b3d74f009fa668
+size 2570728

--- a/example/assets/avatar/parts/BaseballJersey_PlainBlack_01.glb
+++ b/example/assets/avatar/parts/BaseballJersey_PlainBlack_01.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0684d21267e24d5c8f5688debc452ce09232a5ee73f95e5030c9660cfe12c8d
+size 2996428

--- a/example/assets/avatar/parts/FemaleBody.glb
+++ b/example/assets/avatar/parts/FemaleBody.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5c735ba20076dcf82b45224fa80b888fa89a169b3cbebfcc527c1834ce9c5f7
+size 4437724

--- a/example/web-avatar-client/src/AvatarEditor.tsx
+++ b/example/web-avatar-client/src/AvatarEditor.tsx
@@ -16,7 +16,7 @@ import {
 import React, { useCallback, useEffect, useState } from "react";
 import { Group, Object3D } from "three";
 
-import idleAnimationURL from "../../assets/avatar/anims/AS_Andor_Stand_Idle.glb";
+import idleAnimationURL from "../../assets/avatar/anims/idle.glb";
 import hdrURL from "../../assets/hdr/puresky_2k.hdr";
 
 type BodyPartTypes = "fullBody" | "head" | "upperBody" | "lowerBody" | "feet";

--- a/example/web-avatar-client/src/collection.json
+++ b/example/web-avatar-client/src/collection.json
@@ -2,7 +2,7 @@
   "fullBody": [
     {
       "name": "Full Body 1",
-      "asset": "/assets/avatar/parts/SK_Outfit_Body_Male.glb",
+      "asset": "/assets/avatar/parts/FemaleBody.glb",
       "thumb": "/assets/avatar/thumbs/SK_Outfit_Body_Male.jpg"
     }
   ],
@@ -36,7 +36,7 @@
     },
     {
       "name": "Dude Upper Body 3",
-      "asset": "/assets/avatar/parts/SK_Outfit_Three_Flanel_Shirt_01.glb",
+      "asset": "/assets/avatar/parts/BaseballJersey_PlainBlack_01.glb",
       "thumb": "/assets/avatar/thumbs/SK_Outfit_Three_Flanel_Shirt_01.jpg"
     }
   ],

--- a/example/web-avatar-client/src/mmlCharacterDescription.ts
+++ b/example/web-avatar-client/src/mmlCharacterDescription.ts
@@ -3,7 +3,7 @@
 //
 
 export const mmlCharacterDescription: string = `
-<m-character src="/assets/avatar/parts/SK_Outfit_Body_Male.glb">
+<m-character src="/assets/avatar/parts/FemaleBody.glb">
   <m-model src="/assets/avatar/parts/SK_Outfit_Hat_02.glb"></m-model>
   <m-model src="/assets/avatar/parts/SK_Outfit_Two_Long_Coat_with_Collared_Shirt_01.glb"></m-model>
   <m-model src="/assets/avatar/parts/SK_Outfit_Three_Tight_Jeans_with_Chain_01.glb"></m-model>

--- a/packages/3d-web-avatar/src/character/MMLCharacter.ts
+++ b/packages/3d-web-avatar/src/character/MMLCharacter.ts
@@ -69,15 +69,9 @@ export class MMLCharacter {
   public async mergeBodyParts(
     fullBodyURL: string,
     bodyParts: Array<MMLCharacterDescriptionPart>,
-    mainBodyTest: boolean = false,
   ): Promise<Object3D> {
     const fullBodyAsset = await this.modelLoader.load(fullBodyURL);
     const fullBodyGLTF = this.skeletonHelpers.cloneGLTF(fullBodyAsset as GLTF, "fullBody");
-
-    if (mainBodyTest && fullBodyAsset) {
-      return fullBodyAsset.scene;
-    }
-
     const assetPromises: Array<Promise<{ asset: GLTF; part: MMLCharacterDescriptionPart }>> =
       bodyParts.map((part) => {
         return new Promise((resolve) => {

--- a/packages/3d-web-avatar/src/character/MMLCharacter.ts
+++ b/packages/3d-web-avatar/src/character/MMLCharacter.ts
@@ -5,6 +5,7 @@ import {
   Group,
   MathUtils,
   Matrix4,
+  MeshStandardMaterial,
   Object3D,
   Skeleton,
   SkinnedMesh,
@@ -158,6 +159,7 @@ export class MMLCharacter {
             skinnedMeshClone.castShadow = true;
             skinnedMeshClone.receiveShadow = true;
             skinnedMeshClone.bind(this.sharedSkeleton!, this.sharedMatrixWorld!);
+            skinnedMeshClone.children = [];
             this.skinnedMeshesParent?.add(skinnedMeshClone);
           }
         });

--- a/packages/3d-web-avatar/src/character/MMLCharacter.ts
+++ b/packages/3d-web-avatar/src/character/MMLCharacter.ts
@@ -5,7 +5,6 @@ import {
   Group,
   MathUtils,
   Matrix4,
-  Mesh,
   Object3D,
   Skeleton,
   SkinnedMesh,
@@ -69,9 +68,14 @@ export class MMLCharacter {
   public async mergeBodyParts(
     fullBodyURL: string,
     bodyParts: Array<MMLCharacterDescriptionPart>,
+    mainBodyTest: boolean = false,
   ): Promise<Object3D> {
     const fullBodyAsset = await this.modelLoader.load(fullBodyURL);
     const fullBodyGLTF = this.skeletonHelpers.cloneGLTF(fullBodyAsset as GLTF, "fullBody");
+
+    if (mainBodyTest && fullBodyAsset) {
+      return fullBodyAsset.scene;
+    }
 
     const assetPromises: Array<Promise<{ asset: GLTF; part: MMLCharacterDescriptionPart }>> =
       bodyParts.map((part) => {

--- a/packages/3d-web-standalone-avatar-editor/src/screenshot/ModelScreenshotter.ts
+++ b/packages/3d-web-standalone-avatar-editor/src/screenshot/ModelScreenshotter.ts
@@ -47,8 +47,6 @@ export class ModelScreenshotter {
     const size = new Vector3();
     boundingBox.getSize(size);
 
-    console.log("boundingBox", boundingBox);
-
     const camera = new PerspectiveCamera(50, width / height, 0.1, 1000);
     positionCameraToFitBoundingBox(camera, boundingBox, size, padding, [0, 15, 30]);
 


### PR DESCRIPTION
This PR implements a cleanup method for the `3d-web-avatar` package that prevents the animation mixer from applying influences other than rotation/quaternion to the skeletal mesh when animating an avatar in the avatar editor.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
