### PR TITLE
improves SSAO quality vs performance balance

### DIFF
--- a/packages/3d-web-client-core/src/tweakpane/blades/ssaoFolder.ts
+++ b/packages/3d-web-client-core/src/tweakpane/blades/ssaoFolder.ts
@@ -40,7 +40,7 @@ const ppssaoOptions = {
 
 export const n8ssaoValues = {
   enabled: true,
-  halfRes: false,
+  halfRes: true,
   aoRadius: 5,
   distanceFalloff: 3.0,
   intensity: 1.0,


### PR DESCRIPTION
This PR aims to improve the quality VS performance balance for the screen-space ambient occlusion, as using half-res for the post-processing step offers a very decent quality with a much faster performance.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
