### PR TITLE
Fix conflicting user id in user networking server

### DIFF
--- a/packages/3d-web-user-networking/test/UserNetworking.test.ts
+++ b/packages/3d-web-user-networking/test/UserNetworking.test.ts
@@ -91,7 +91,7 @@ describe("UserNetworking", () => {
     expect(await user1IdentityPromise).toEqual(1);
 
     await waitUntil(
-      () => (server as any).allClients.size === 1,
+      () => (server as any).allClientsById.size === 1,
       "wait for server to see the presence of user 1",
     );
 
@@ -138,7 +138,7 @@ describe("UserNetworking", () => {
     expect(await user2IdentityPromise).toEqual(2);
 
     await waitUntil(
-      () => (server as any).allClients.size === 2,
+      () => (server as any).allClientsById.size === 2,
       "wait for server to see the presence of user 2",
     );
 
@@ -209,7 +209,7 @@ describe("UserNetworking", () => {
     user2.stop();
 
     await waitUntil(
-      () => (server as any).allClients.size === 1,
+      () => (server as any).allClientsById.size === 1,
       "wait for server to see the removal of user 2",
     );
 
@@ -221,7 +221,7 @@ describe("UserNetworking", () => {
     user1.stop();
 
     await waitUntil(
-      () => (server as any).allClients.size === 0,
+      () => (server as any).allClientsById.size === 0,
       "wait for server to see the removal of user 1",
     );
 


### PR DESCRIPTION
Fixes a race condition where if a user allocate and id does not authenticate soon enough then the id given to them can also be given to another connecting client.

The fix is to use a map containing the ids to limit which ids can be given out.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix