### PR TITLE
Collisions visualizer toggler

### DIFF
--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -58,6 +58,38 @@ export class CollisionsManager {
   constructor(scene: Scene) {
     this.scene = scene;
     this.collisionTrigger = MMLCollisionTrigger.init();
+    this.toggleDebug = this.toggleDebug.bind(this);
+  }
+
+  public toggleDebug() {
+    this.debug = !this.debug;
+
+    this.collisionMeshState.forEach((meshState) => {
+      if (this.debug) {
+        if (!meshState.debugGroup) {
+          meshState.debugGroup = this.createDebugVisuals(meshState);
+          this.scene.add(meshState.debugGroup);
+        }
+      } else {
+        if (meshState.debugGroup) {
+          this.scene.remove(meshState.debugGroup);
+          // Dispose of all resources used by the debug visuals, including materials and geometries.
+          meshState.debugGroup.traverse((object) => {
+            // Because MeshBVH can have its own variable complexity in terms of creating geometries
+            // and materials for its Helper, insteach of checking for instanceof Meshes and disposing
+            // their materials and geometries, we'll check for the existence of a dispose() function.
+            // During tests, this revealed to be safe, and an effective way to toggle the debug
+            // on and off while ending up with the original number of geometries on the scene, with no
+            // leftovers (no memory leak).
+            if (typeof (object as any).dispose === "function") {
+              (object as any).dispose();
+            }
+          });
+          meshState.debugGroup.clear();
+          meshState.debugGroup = undefined;
+        }
+      }
+    });
   }
 
   public raycastFirst(ray: Ray): [number, Vector3, CollisionMeshState] | null {
@@ -86,6 +118,31 @@ export class CollisionsManager {
       return null;
     }
     return [minimumDistance, minimumNormal, minimumHit];
+  }
+
+  private createDebugVisuals(meshState: CollisionMeshState): Group {
+    const geometry = meshState.meshBVH.geometry;
+
+    // Cast to add the boundsTree property to the geometry so that the MeshBVHHelper can find it
+    (geometry as any).boundsTree = meshState.meshBVH;
+    const wireframeMesh = new Mesh(geometry, new MeshBasicMaterial({ wireframe: true }));
+    wireframeMesh.name = "wireframe mesh";
+    const normalsHelper = new VertexNormalsHelper(wireframeMesh, 0.25, 0x00ff00);
+    normalsHelper.name = "normals helper";
+    const visualizer = new MeshBVHHelper(wireframeMesh, 4);
+    visualizer.name = "meshBVH visualizer";
+    (visualizer.edgeMaterial as LineBasicMaterial).color = new Color("blue");
+
+    const debugGroup = new Group();
+    debugGroup.add(wireframeMesh, normalsHelper, visualizer as unknown as Object3D);
+    meshState.source.matrixWorld.decompose(
+      debugGroup.position,
+      debugGroup.quaternion,
+      debugGroup.scale,
+    );
+    visualizer.update();
+
+    return debugGroup;
   }
 
   private createCollisionMeshState(group: Group, trackCollisions: boolean): CollisionMeshState {
@@ -124,26 +181,15 @@ export class CollisionsManager {
       meshBVH,
       matrix: group.matrixWorld.clone(),
       trackCollisions,
+      debugGroup: this.debug
+        ? this.createDebugVisuals({
+            source: group,
+            meshBVH: meshBVH,
+            matrix: group.matrixWorld.clone(),
+            trackCollisions,
+          })
+        : undefined,
     };
-    if (this.debug) {
-      // Have to cast to add the boundsTree property to the geometry so that the MeshBVHHelper can find it
-      (newBufferGeometry as any).boundsTree = meshBVH;
-
-      const wireframeMesh = new Mesh(newBufferGeometry, new MeshBasicMaterial({ wireframe: true }));
-
-      const normalsHelper = new VertexNormalsHelper(wireframeMesh, 0.25, 0x00ff00);
-
-      const visualizer = new MeshBVHHelper(wireframeMesh, 4);
-      (visualizer.edgeMaterial as LineBasicMaterial).color = new Color("blue");
-
-      const debugGroup = new Group();
-      debugGroup.add(wireframeMesh, normalsHelper, visualizer as unknown as Object3D);
-
-      group.matrixWorld.decompose(debugGroup.position, debugGroup.quaternion, debugGroup.scale);
-      visualizer.update();
-
-      meshState.debugGroup = debugGroup;
-    }
     return meshState;
   }
 

--- a/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
+++ b/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
@@ -17,6 +17,7 @@ import { TimeManager } from "../time/TimeManager";
 
 import { BrightnessContrastSaturationFolder } from "./blades/bcsFolder";
 import { CharacterFolder } from "./blades/characterFolder";
+import { CollisionsStatsFolder } from "./blades/collisionsStatsFolder";
 import { EnvironmentFolder } from "./blades/environmentFolder";
 import { PostExtrasFolder } from "./blades/postExtrasFolder";
 import { RendererFolder, rendererValues } from "./blades/rendererFolder";
@@ -30,6 +31,7 @@ export class TweakPane {
   private gui: Pane;
 
   private renderStatsFolder: RendererStatsFolder;
+  private collisionsStatsFolder: CollisionsStatsFolder;
   private rendererFolder: RendererFolder;
   private toneMappingFolder: ToneMappingFolder;
   private ssaoFolder: SSAOFolder;
@@ -49,6 +51,7 @@ export class TweakPane {
     private renderer: WebGLRenderer,
     private scene: Scene,
     private composer: EffectComposer,
+    private toggleCollisionsDebug: () => void,
   ) {
     const tweakPaneWrapper = document.createElement("div");
     tweakPaneWrapper.style.position = "fixed";
@@ -84,6 +87,7 @@ export class TweakPane {
     document.head.appendChild(styleElement);
 
     this.renderStatsFolder = new RendererStatsFolder(this.gui, true);
+    this.collisionsStatsFolder = new CollisionsStatsFolder(this.gui, false);
     this.rendererFolder = new RendererFolder(this.gui, false);
     this.toneMappingFolder = new ToneMappingFolder(this.gui, false);
     this.ssaoFolder = new SSAOFolder(this.gui, false);
@@ -95,6 +99,8 @@ export class TweakPane {
     this.toneMappingFolder.folder.hidden = rendererValues.toneMapping === 5 ? false : true;
 
     this.export = this.gui.addFolder({ title: "import / export", expanded: false });
+
+    this.collisionsStatsFolder.setupChangeEvent(this.toggleCollisionsDebug);
 
     window.addEventListener("keydown", this.processKey.bind(this));
     this.setupRenderPane = this.setupRenderPane.bind(this);

--- a/packages/3d-web-client-core/src/tweakpane/blades/collisionsStatsFolder.ts
+++ b/packages/3d-web-client-core/src/tweakpane/blades/collisionsStatsFolder.ts
@@ -1,0 +1,17 @@
+import { ButtonApi, FolderApi } from "tweakpane";
+
+export class CollisionsStatsFolder {
+  private folder: FolderApi;
+  private debugButton: ButtonApi;
+
+  constructor(parentFolder: FolderApi, expanded: boolean = true) {
+    this.folder = parentFolder.addFolder({ title: "collisions", expanded: expanded });
+    this.debugButton = this.folder.addButton({ title: "Toggle Debug" });
+  }
+
+  public setupChangeEvent(toggleDebug: () => void): void {
+    this.debugButton.on("click", () => {
+      toggleDebug();
+    });
+  }
+}

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -136,6 +136,7 @@ export class Networked3dWebExperienceClient {
       this.composer.renderer,
       this.scene,
       this.composer.effectComposer,
+      this.collisionsManager.toggleDebug,
     );
     this.composer.setupTweakPane(this.tweakPane);
 


### PR DESCRIPTION
This PR aims to refactor the creation of the `CollisionsManager` visual helpers so they can dynamically added and removed from the scene.

When creating MML objects dynamically for a 3D web experience, the CollisionsManager visual helpers have proven to be very handy in inspecting the scene in cases when objects overlap (sometimes causing depth sorting visual glitches that are hard to spot on a first look).

As we already have them anyway under a `debug` flag in the CollisionsManager class, it would be helpful to be able to toggle them on and off dynamically.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)


https://github.com/mml-io/3d-web-experience/assets/33723163/b8b72a07-987c-4b43-b850-931d38e4750c

