### PR TITLE
user-auth: Add server-induced userData updates

### DIFF
--- a/packages/3d-web-experience-server/src/Networked3dWebExperienceServer.ts
+++ b/packages/3d-web-experience-server/src/Networked3dWebExperienceServer.ts
@@ -96,6 +96,11 @@ export class Networked3dWebExperienceServer {
     });
   }
 
+  public updateUserCharacter(clientId: number, userData: UserData) {
+    console.log(`Initiate server-side update of client ${clientId}`);
+    this.userNetworkingServer.updateUserCharacter(clientId, userData);
+  }
+
   registerExpressRoutes(app: enableWs.Application) {
     app.ws(this.config.networkPath, (ws) => {
       this.userNetworkingServer.connectClient(ws);


### PR DESCRIPTION
In several occasions server-side logic may want to induce an (enforced) userData update, distributed to all players.

Examples:
- Moderating: Changing offensive usernames and/or characters
- Ownership-based: Loss of ownership of a certain character or characterDescription-Item (includes e.g. NFT-Transfers, when items are represented as NFT)
- Game-Events: A group of Users, e.g. the winning team of a challenge, should get awared with a special character or character item.


**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:
