### PR TITLE
user-auth: Make generateAuthorizedSessionToken async

### DIFF
--- a/example/multi-user-3d-web-experience/server/src/BasicUserAuthenticator.ts
+++ b/example/multi-user-3d-web-experience/server/src/BasicUserAuthenticator.ts
@@ -30,7 +30,7 @@ export class BasicUserAuthenticator {
     private options: BasicUserAuthenticatorOptions = defaultOptions,
   ) {}
 
-  public generateAuthorizedSessionToken(req: express.Request): string {
+  public async generateAuthorizedSessionToken(req: express.Request): Promise<string> {
     const sessionToken = crypto.randomBytes(20).toString("hex");
     const authUser: AuthUser = {
       clientId: null,

--- a/example/server/src/BasicUserAuthenticator.ts
+++ b/example/server/src/BasicUserAuthenticator.ts
@@ -30,7 +30,7 @@ export class BasicUserAuthenticator {
     private options: BasicUserAuthenticatorOptions = defaultOptions,
   ) {}
 
-  public generateAuthorizedSessionToken(req: express.Request): string {
+  public async generateAuthorizedSessionToken(req: express.Request): Promise<string> {
     const sessionToken = crypto.randomBytes(20).toString("hex");
     const authUser: AuthUser = {
       clientId: null,

--- a/packages/3d-web-experience-server/src/Networked3dWebExperienceServer.ts
+++ b/packages/3d-web-experience-server/src/Networked3dWebExperienceServer.ts
@@ -9,7 +9,7 @@ import { MMLDocumentsServer } from "./MMLDocumentsServer";
 import { websocketDirectoryChangeListener } from "./websocketDirectoryChangeListener";
 
 type UserAuthenticator = {
-  generateAuthorizedSessionToken(req: express.Request): string | null;
+  generateAuthorizedSessionToken(req: express.Request): Promise<string | null>;
   getClientIdForSessionToken: (sessionToken: string) => {
     id: number;
   } | null;
@@ -110,8 +110,8 @@ export class Networked3dWebExperienceServer {
 
     const webClientServing = this.config.webClientServing;
     if (webClientServing) {
-      app.get(webClientServing.indexUrl, (req: express.Request, res: express.Response) => {
-        const token = this.config.userAuthenticator.generateAuthorizedSessionToken(req);
+      app.get(webClientServing.indexUrl, async (req: express.Request, res: express.Response) => {
+        const token = await this.config.userAuthenticator.generateAuthorizedSessionToken(req);
         if (!token) {
           res.send("Error: Could not generate token");
           return;


### PR DESCRIPTION
For many authorization protocols, external resources are queried. Examples include API-Requests, DB-queries or even blockchain lookups.

This makes the generateAuthorizedSessionToken async to support such protocols in a non-blocking way.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [x] Refactor
- [ ] Tests
- [x] Other, please describe: Minimal improvement for extending and customized UserAuthenticators
