### PR TITLE
replaces ground plane with a simpler geometry

### DIFF
--- a/packages/3d-web-client-core/src/ground-plane/GroundPlane.ts
+++ b/packages/3d-web-client-core/src/ground-plane/GroundPlane.ts
@@ -1,12 +1,12 @@
 import {
   CanvasTexture,
-  CircleGeometry,
   FrontSide,
   Group,
   LinearMipMapLinearFilter,
   Mesh,
   MeshStandardMaterial,
   NearestFilter,
+  PlaneGeometry,
   RepeatWrapping,
   Texture,
 } from "three";
@@ -25,7 +25,7 @@ ctx.fillRect(1, 1, 1, 1);
 export class GroundPlane extends Group {
   private readonly floorSize = 210;
   private readonly floorTexture: Texture | null = null;
-  private readonly floorGeometry = new CircleGeometry(this.floorSize, this.floorSize);
+  private readonly floorGeometry = new PlaneGeometry(this.floorSize, this.floorSize, 1, 1);
   private readonly floorMaterial: MeshStandardMaterial;
   private readonly floorMesh: Mesh | null = null;
 


### PR DESCRIPTION
This PR replaces the old ground geometry (an unnecessary CircleGeometry with 210 segments) on `3d-web-client-core`, with a simpler PlaneGeometry with only 2 triangles.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
