### PR TITLE
Add avatar configuration to change default avatar

### DIFF
--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -29,7 +29,7 @@ const app = new Networked3dWebExperienceClient(holder, {
   environmentConfiguration: {},
   avatarConfig: {
     availableAvatars: [],
-  },
+  }
 });
 
 app.update();

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -27,6 +27,9 @@ const app = new Networked3dWebExperienceClient(holder, {
   skyboxHdrJpgUrl: hdrJpgUrl,
   mmlDocuments: [{ url: `${protocol}//${host}/mml-documents/example-mml.html` }],
   environmentConfiguration: {},
+  avatarConfig: {
+    availableAvatars: [],
+  },
 });
 
 app.update();

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -29,7 +29,7 @@ const app = new Networked3dWebExperienceClient(holder, {
   environmentConfiguration: {},
   avatarConfig: {
     availableAvatars: [],
-  }
+  },
 });
 
 app.update();

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -63,6 +63,18 @@ type MMLDocumentConfiguration = {
   };
 };
 
+type AvatarConfig = {
+  availableAvatars: Array<{
+    avatarFileType: "glb" | "html";
+    thumbnailUrl?: string;
+    isDefaultAvatar?: boolean;
+    avatarFileUrl: string;
+    avatarName?: string;
+  }>;
+  allowCustomAvatars?: boolean;
+  customAvatarWebhookUrl?: string;
+};
+
 export type Networked3dWebExperienceClientConfig = {
   sessionToken: string;
   chatNetworkAddress?: string;
@@ -76,6 +88,7 @@ export type Networked3dWebExperienceClientConfig = {
   skyboxHdrJpgUrl: string;
   enableTweakPane?: boolean;
   updateURLLocation?: boolean;
+  avatarConfig?: AvatarConfig;
 };
 
 export class Networked3dWebExperienceClient {
@@ -423,10 +436,24 @@ export class Networked3dWebExperienceClient {
       throw new Error("Own identity not found");
     }
 
+    const defaultAvatar =
+      this.config.avatarConfig?.availableAvatars.find((avatar) => avatar.isDefaultAvatar) ??
+      this.config.avatarConfig?.availableAvatars[0];
+
+    const characterDescription = defaultAvatar
+      ? ({
+          meshFileUrl:
+            defaultAvatar.avatarFileType === "glb" ? defaultAvatar.avatarFileUrl : undefined,
+          mmlCharacterUrl:
+            defaultAvatar.avatarFileType === "html" ? defaultAvatar.avatarFileUrl : undefined,
+          mmlCharacterString: undefined,
+        } as CharacterDescription)
+      : ownIdentity.characterDescription;
+
     this.characterManager.spawnLocalCharacter(
       this.clientId!,
       ownIdentity.username,
-      ownIdentity.characterDescription,
+      characterDescription,
       spawnPosition,
       spawnRotation,
     );

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -63,14 +63,33 @@ type MMLDocumentConfiguration = {
   };
 };
 
+type AvatarType = | {
+      thumbnailUrl?: string;
+      name?: string;
+      meshFileUrl: string;
+      mmlCharacterString?: null;
+      mmlCharacterUrl?: null;
+      isDefaultAvatar?: boolean;
+    }
+  | {
+      thumbnailUrl?: string;
+      name?: string;
+      meshFileUrl?: null;
+      mmlCharacterString: string;
+      mmlCharacterUrl?: null;
+      isDefaultAvatar?: boolean;
+    }
+  | {
+      thumbnailUrl?: string;
+      name?: string;
+      meshFileUrl?: null;
+      mmlCharacterString?: null;
+      mmlCharacterUrl: string;
+      isDefaultAvatar?: boolean;
+    };
+
 type AvatarConfig = {
-  availableAvatars: Array<{
-    avatarFileType: "glb" | "html";
-    thumbnailUrl?: string;
-    isDefaultAvatar?: boolean;
-    avatarFileUrl: string;
-    avatarName?: string;
-  }>;
+  availableAvatars: Array<AvatarType>;
   allowCustomAvatars?: boolean;
   customAvatarWebhookUrl?: string;
 };
@@ -443,10 +462,10 @@ export class Networked3dWebExperienceClient {
     const characterDescription = defaultAvatar
       ? ({
           meshFileUrl:
-            defaultAvatar.avatarFileType === "glb" ? defaultAvatar.avatarFileUrl : undefined,
+            defaultAvatar.meshFileUrl ?? undefined,
           mmlCharacterUrl:
-            defaultAvatar.avatarFileType === "html" ? defaultAvatar.avatarFileUrl : undefined,
-          mmlCharacterString: undefined,
+            defaultAvatar.mmlCharacterUrl ?? undefined,
+          mmlCharacterString: defaultAvatar.mmlCharacterString ?? undefined,
         } as CharacterDescription)
       : ownIdentity.characterDescription;
 

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -63,7 +63,8 @@ type MMLDocumentConfiguration = {
   };
 };
 
-type AvatarType = | {
+type AvatarType =
+  | {
       thumbnailUrl?: string;
       name?: string;
       meshFileUrl: string;
@@ -461,10 +462,8 @@ export class Networked3dWebExperienceClient {
 
     const characterDescription = defaultAvatar
       ? ({
-          meshFileUrl:
-            defaultAvatar.meshFileUrl ?? undefined,
-          mmlCharacterUrl:
-            defaultAvatar.mmlCharacterUrl ?? undefined,
+          meshFileUrl: defaultAvatar.meshFileUrl ?? undefined,
+          mmlCharacterUrl: defaultAvatar.mmlCharacterUrl ?? undefined,
           mmlCharacterString: defaultAvatar.mmlCharacterString ?? undefined,
         } as CharacterDescription)
       : ownIdentity.characterDescription;


### PR DESCRIPTION
**What kind of change does your PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

This commit adds basic support for avatar configuration. It accepts a list of available Avatars (among other properties) and automatically uses either:

The one with the property "isDefaultAvatar" set to true
The first avatar of the list

In case the `availableAvatars` list is empty, it will use the default one