### PR TITLE
Fix duplicate chat connection id crash

### DIFF
--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -360,7 +360,7 @@ export class Networked3dWebExperienceClient {
       this.networkChat = new ChatNetworkingClient({
         url: this.config.chatNetworkAddress,
         sessionToken: this.config.sessionToken,
-        websocketFactory: (url: string) => new WebSocket(`${url}?id=${this.clientId}`),
+        websocketFactory: (url: string) => new WebSocket(url),
         statusUpdateCallback: (status: WebsocketStatus) => {
           if (status === WebsocketStatus.Disconnected || status === WebsocketStatus.Reconnecting) {
             // The connection was lost after being established - the connection may be re-established with a different client ID

--- a/packages/3d-web-text-chat/src/chat-network/ChatNetworkingServer.ts
+++ b/packages/3d-web-text-chat/src/chat-network/ChatNetworkingServer.ts
@@ -108,7 +108,13 @@ export class ChatNetworkingServer {
             return;
           }
           if (this.clientsById.has(authResponse.id)) {
-            throw new Error(`Client already connected with ID: ${authResponse.id}`);
+            /*
+             This client is already connected. Reject the connection. If the old connection is abandoned then it will
+             be removed and retry attempts will succeed.
+            */
+            console.error(`Client already connected with ID: ${authResponse.id}`);
+            socket.close();
+            return;
           }
           client.id = authResponse.id;
           this.clientsById.set(client.id, client);


### PR DESCRIPTION
Fixes an issue where old/flaky connections that a client has abandoned are still tracked by the server and retry attempts from the client would result in a collision and an error was thrown.

The change in behaviour is to explicitly reject these new incoming attempts in favour of maintaining the old connection until that old connection fails a heartbeat.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
