### PR TITLE
Fixed loading avatars with interleaved buffers (#159)

### DIFF
--- a/packages/3d-web-client-core/src/character/Character.ts
+++ b/packages/3d-web-client-core/src/character/Character.ts
@@ -70,6 +70,9 @@ export class Character extends Group {
 
   private async load(): Promise<void> {
     const previousModel = this.model;
+    if (previousModel && previousModel.mesh) {
+      this.remove(previousModel.mesh!);
+    }
     this.model = new CharacterModel({
       characterDescription: this.config.characterDescription,
       animationConfig: this.config.animationConfig,
@@ -79,9 +82,6 @@ export class Character extends Group {
       isLocal: this.config.isLocal,
     });
     await this.model.init();
-    if (previousModel && previousModel.mesh) {
-      this.remove(previousModel.mesh!);
-    }
     this.add(this.model.mesh!);
     if (this.speakingIndicator === null) {
       this.speakingIndicator = new CharacterSpeakingIndicator(this.config.composer.postPostScene);


### PR DESCRIPTION
Resolves #159 (incidentally).

This PR resolves an issue where avatars that have been loaded as gLTF files that use interleaved buffers would be visually corrupted by the process of remapping the bone indices of child models to the parent model's bone indices because the code reading the buffer did not account for interleaved buffers and would read the data relating to other attributes as bone indices.

The change in this PR is to use accessors on the relevant classes rather than reading the array directly.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] The title references the corresponding issue # (if relevant)
