### PR TITLE
Fix race condition of disconnecting during auth (#169)

### DIFF
--- a/packages/3d-web-user-networking/src/UserNetworkingServer.ts
+++ b/packages/3d-web-user-networking/src/UserNetworkingServer.ts
@@ -121,6 +121,10 @@ export class UserNetworkingServer {
         if (!client.authenticatedUser) {
           if (parsed.type === USER_NETWORKING_USER_AUTHENTICATE_MESSAGE_TYPE) {
             this.handleUserAuth(client, parsed).then((authResult) => {
+              if (client.socket.readyState !== WebSocketOpenStatus) {
+                // The client disconnected before the authentication was completed
+                return;
+              }
               if (!authResult) {
                 // If the user is not authorized, disconnect the client
                 const serverError = JSON.stringify({
@@ -147,6 +151,7 @@ export class UserNetworkingServer {
                 }
 
                 const userData = authResult;
+                client.authenticatedUser = userData;
 
                 // Give the client its own profile
                 const userProfileMessage = JSON.stringify({
@@ -262,7 +267,6 @@ export class UserNetworkingServer {
     }
 
     console.log("Client authenticated", client.id, resolvedUserData);
-    client.authenticatedUser = resolvedUserData;
 
     return resolvedUserData;
   }


### PR DESCRIPTION
Resolves #169.

This PR fixes an issue where if a user disconnected whilst the asynchronous auth process was ongoing then the auth would complete and result in inconsistent state.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] The title references the corresponding issue # (if relevant)
