### PR TITLE
use npm config to set NPM auth token in github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -108,7 +108,7 @@ jobs:
           git config --global user.name "lerna-ci-mml"
 
           # Set up npm auth token from secret for publishing
-          echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+          npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
           # Publish the current commit as an "experimental" version
           version="0.0.0-experimental-$(git rev-parse --short HEAD)-$(date +'%Y%m%d')"
@@ -140,7 +140,7 @@ jobs:
           git config --global user.name "lerna-ci-mml"
 
           # Set up npm auth token from secret for publishing
-          echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+          npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
           # Attempt to publish at the current version - this will skip if the version already exists
           echo "Attempting to publishing latest version"


### PR DESCRIPTION
The previous PR committed the .npmrc which means we now get publish errors that
it has uncommitted changes once the auth token is added in the CI. This
commit uses `npm config set //<registry>:...` to add the token to the
user config in order to keep the repository config clean.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
