### PR TITLE
fixes initial sun positioning according to Environment Configuration

### DIFF
--- a/packages/3d-web-client-core/src/rendering/composer.ts
+++ b/packages/3d-web-client-core/src/rendering/composer.ts
@@ -540,11 +540,13 @@ export class Composer {
     }
     if (typeof this.environmentConfiguration?.sun?.azimuthalAngle === "number") {
       sunValues.sunPosition.sunAzimuthalAngle = this.environmentConfiguration.sun.azimuthalAngle;
-      this.sun?.setAzimuthalAngle(this.environmentConfiguration.sun.azimuthalAngle);
+      this.sun?.setAzimuthalAngle(
+        this.environmentConfiguration.sun.azimuthalAngle * (Math.PI / 180),
+      );
     }
     if (typeof this.environmentConfiguration?.sun?.polarAngle === "number") {
       sunValues.sunPosition.sunPolarAngle = this.environmentConfiguration.sun.polarAngle;
-      this.sun?.setPolarAngle(this.environmentConfiguration.sun.polarAngle);
+      this.sun?.setPolarAngle(this.environmentConfiguration.sun.polarAngle * (Math.PI / 180));
     }
   }
 


### PR DESCRIPTION
This PR fixes the initial sun positioning according to the `EnvironmentConfiguration` properties.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
