### PR TITLE
Fixes spawn usage with env vars on Windows (#178)

### DIFF
--- a/example/local-only-multi-user-3d-web-experience/server/package.json
+++ b/example/local-only-multi-user-3d-web-experience/server/package.json
@@ -11,7 +11,7 @@
     "build": "rimraf ./build && tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
     "iterate:start": "node ./build/index.js",
-    "start": "NODE_ENV=production node build/index.js",
+    "start": "cross-env NODE_ENV=production node build/index.js",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"

--- a/example/multi-user-3d-web-experience/server/package.json
+++ b/example/multi-user-3d-web-experience/server/package.json
@@ -11,7 +11,7 @@
     "build": "rimraf ./build && tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
     "iterate:start": "node ./build/index.js",
-    "start": "NODE_ENV=production node build/index.js",
+    "start": "cross-env NODE_ENV=production node build/index.js",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"

--- a/example/web-avatar-editor/server/package.json
+++ b/example/web-avatar-editor/server/package.json
@@ -11,7 +11,7 @@
     "build": "rimraf ./build && tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
     "iterate:start": "node ./build/index.js",
-    "start": "NODE_ENV=production node build/index.js",
+    "start": "cross-env NODE_ENV=production node build/index.js",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/parser": "^7.15.0",
         "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "esbuild": "0.20.2",
         "esbuild-plugin-copy": "2.1.1",
         "eslint": "^8.57.0",
@@ -5715,6 +5716,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "esbuild": "0.20.2",
     "esbuild-plugin-copy": "2.1.1",
     "eslint": "^8.57.0",
@@ -45,8 +46,8 @@
     "rfc6902": "^5.1.1",
     "rimraf": "^5.0.8",
     "tmp": "^0.2.3",
-    "ts-node": "^10.9.2",
     "ts-jest": "29.1.5",
+    "ts-node": "^10.9.2",
     "tsx": "4.16.2",
     "typescript": "^5.5.3"
   }

--- a/packages/3d-web-avatar-editor-ui/package.json
+++ b/packages/3d-web-avatar-editor-ui/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
-    "start": "NODE_ENV=production node build/index.js 2>error.log",
+    "start": "cross-env NODE_ENV=production node build/index.js 2>error.log",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix",

--- a/packages/3d-web-avatar/package.json
+++ b/packages/3d-web-avatar/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
-    "start": "NODE_ENV=production node build/index.js 2>error.log",
+    "start": "cross-env NODE_ENV=production node build/index.js 2>error.log",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix",

--- a/packages/3d-web-standalone-avatar-editor/package.json
+++ b/packages/3d-web-standalone-avatar-editor/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsx ./build.ts --build",
     "iterate": "tsx ./build.ts --watch",
-    "start": "NODE_ENV=production node build/index.js 2>error.log",
+    "start": "cross-env NODE_ENV=production node build/index.js 2>error.log",
     "type-check": "tsc --noEmit",
     "lint": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --max-warnings 0",
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"

--- a/utils/rebuildOnDependencyChangesPlugin.ts
+++ b/utils/rebuildOnDependencyChangesPlugin.ts
@@ -35,8 +35,9 @@ export const rebuildOnDependencyChangesPlugin = {
           });
         });
       }
-      runningProcess = spawn("npm", ["run", "iterate:start"], {
+      runningProcess = spawn("npm run iterate:start", {
         stdio: "inherit",
+        shell: true,
       });
     });
   },


### PR DESCRIPTION
Fixes #178.

* Uses `cross-env` to add env var support on Windows
* Runs `spawn` with `shell: true` to fix `npm` not being found

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR fulfill the following requirements?**

- [x] The title references the corresponding issue # (if relevant)
