### PR TITLE
implements the toggleable orbital camera

### DIFF
--- a/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
@@ -100,7 +100,7 @@ export class LocalAvatarClient {
 
     this.composer = new Composer({
       scene: this.scene,
-      camera: this.cameraManager.camera,
+      cameraManager: this.cameraManager,
       spawnSun: true,
     });
     this.composer.useHDRJPG(hdrJpgUrl);

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -34,6 +34,7 @@ const app = new Networked3dWebExperienceClient(holder, {
   avatarConfiguration: {
     availableAvatars: [],
   },
+  allowOrbitalCamera: true,
   loadingScreen: {
     background: "#424242",
     color: "#ffffff",

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -172,19 +172,19 @@ export class LocalController {
   }
 
   private updateAzimuthalAngle(): void {
-    const camToModelDistance = this.config.cameraManager.camera.position.distanceTo(
+    const camToModelDistance = this.config.cameraManager.activeCamera.position.distanceTo(
       this.config.character.position,
     );
     const isCameraFirstPerson = camToModelDistance < 2;
     if (isCameraFirstPerson) {
       const cameraForward = this.tempVector
         .set(0, 0, 1)
-        .applyQuaternion(this.config.cameraManager.camera.quaternion);
+        .applyQuaternion(this.config.cameraManager.activeCamera.quaternion);
       this.azimuthalAngle = Math.atan2(cameraForward.x, cameraForward.z);
     } else {
       this.azimuthalAngle = Math.atan2(
-        this.config.cameraManager.camera.position.x - this.config.character.position.x,
-        this.config.cameraManager.camera.position.z - this.config.character.position.z,
+        this.config.cameraManager.activeCamera.position.x - this.config.character.position.x,
+        this.config.cameraManager.activeCamera.position.z - this.config.character.position.z,
       );
     }
   }

--- a/packages/3d-web-client-core/src/index.ts
+++ b/packages/3d-web-client-core/src/index.ts
@@ -5,7 +5,7 @@ export * from "./character/url-position";
 export * from "./helpers/math-helpers";
 export { CharacterModelLoader } from "./character/CharacterModelLoader";
 export { CharacterState, AnimationState } from "./character/CharacterState";
-export { KeyInputManager } from "./input/KeyInputManager";
+export { Key, KeyInputManager } from "./input/KeyInputManager";
 export { VirtualJoystick } from "./input/VirtualJoystick";
 export { MMLCompositionScene } from "./mml/MMLCompositionScene";
 export { TweakPane } from "./tweakpane/TweakPane";

--- a/packages/3d-web-client-core/src/input/KeyInputManager.ts
+++ b/packages/3d-web-client-core/src/input/KeyInputManager.ts
@@ -1,18 +1,23 @@
 import { EventHandlerCollection } from "./EventHandlerCollection";
 import { VirtualJoystick } from "./VirtualJoystick";
 
-enum Key {
+export enum Key {
   W = "w",
   A = "a",
   S = "s",
   D = "d",
   SHIFT = "shift",
   SPACE = " ",
+  C = "c",
 }
+
+type KeyCallback = () => void;
+type BindingsType = Map<Key, KeyCallback>;
 
 export class KeyInputManager {
   private keys = new Map<string, boolean>();
   private eventHandlerCollection = new EventHandlerCollection();
+  private bindings: BindingsType = new Map();
 
   constructor(private shouldCaptureKeyPress: () => boolean = () => true) {
     this.eventHandlerCollection.add(document, "keydown", this.onKeyDown.bind(this));
@@ -41,10 +46,17 @@ export class KeyInputManager {
 
   private onKeyUp(event: KeyboardEvent): void {
     this.keys.set(event.key.toLowerCase(), false);
+    if (this.bindings.has(event.key.toLowerCase() as Key)) {
+      this.bindings.get(event.key.toLowerCase() as Key)!();
+    }
   }
 
   public isKeyPressed(key: string): boolean {
     return this.keys.get(key) || false;
+  }
+
+  public createKeyBinding(key: Key, callback: () => void): void {
+    this.bindings.set(key, callback);
   }
 
   public isMovementKeyPressed(): boolean {
@@ -91,5 +103,6 @@ export class KeyInputManager {
 
   public dispose() {
     this.eventHandlerCollection.clear();
+    this.bindings.clear();
   }
 }

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -77,6 +77,7 @@ type MMLDocumentConfiguration = {
 export type Networked3dWebExperienceClientConfig = {
   userNetworkAddress: string;
   sessionToken: string;
+  allowOrbitalCamera?: boolean;
   chatVisibleByDefault?: boolean;
   userNameToColorOptions?: StringToHslOptions;
   animationConfig: AnimationConfig;
@@ -254,10 +255,12 @@ export class Networked3dWebExperienceClient {
       },
     });
 
-    this.keyInputManager.createKeyBinding(Key.C, () => {
-      this.cameraManager.toggleFlyCamera();
-      this.composer.fitContainer();
-    });
+    if (this.config.allowOrbitalCamera) {
+      this.keyInputManager.createKeyBinding(Key.C, () => {
+        this.cameraManager.toggleFlyCamera();
+        this.composer.fitContainer();
+      });
+    }
 
     this.characterManager = new CharacterManager({
       composer: this.composer,

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -17,6 +17,7 @@ import {
   ErrorScreen,
   getSpawnPositionInsideCircle,
   GroundPlane,
+  Key,
   KeyInputManager,
   LoadingScreen,
   LoadingScreenConfig,
@@ -173,7 +174,7 @@ export class Networked3dWebExperienceClient {
 
     this.composer = new Composer({
       scene: this.scene,
-      camera: this.cameraManager.camera,
+      cameraManager: this.cameraManager,
       spawnSun: true,
       environmentConfiguration: this.config.environmentConfiguration,
     });
@@ -251,6 +252,11 @@ export class Networked3dWebExperienceClient {
       onServerBroadcast: (broadcast: { broadcastType: string; payload: any }) => {
         this.config.onServerBroadcast?.(broadcast);
       },
+    });
+
+    this.keyInputManager.createKeyBinding(Key.C, () => {
+      this.cameraManager.toggleFlyCamera();
+      this.composer.fitContainer();
     });
 
     this.characterManager = new CharacterManager({


### PR DESCRIPTION
This PR aims to implement a secondary toggleable camera (that the user can activate/deactivate by pressing the `c` key) to facilitate taking screenshots or recording video content when using the `3d-web-experience`.

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)

https://github.com/user-attachments/assets/5d90b0b5-591d-438b-a051-0aeb3e276d58
