### PR TITLE
Fix MML collision position reporting

### DIFF
--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -210,6 +210,7 @@ export class CollisionsManager {
     );
 
     let collisionPosition: Vector3 | null = null;
+    let currentCollisionDistance: number = -1;
     meshState.meshBVH.shapecast({
       intersectsBounds: (meshBox) => {
         // Determine if this portion of the mesh overlaps with the capsule bounding box and is therefore worth checking
@@ -241,8 +242,12 @@ export class CollisionsManager {
         if (realDistance < capsuleRadius) {
           if (!collisionPosition) {
             collisionPosition = new Vector3()
-              .copy(closestPointOnSegment)
+              .copy(closestPointOnTriangle)
               .applyMatrix4(meshState.matrix);
+            currentCollisionDistance = realDistance;
+          } else if (realDistance < currentCollisionDistance) {
+            collisionPosition.copy(closestPointOnTriangle).applyMatrix4(meshState.matrix);
+            currentCollisionDistance = realDistance;
           }
           // Calculate the ratio between the real distance and the mesh-space distance
           const ratio = realDistance / modelReferenceDistance;

--- a/packages/3d-web-client-core/src/collisions/getRelativePositionAndRotationRelativeToObject.ts
+++ b/packages/3d-web-client-core/src/collisions/getRelativePositionAndRotationRelativeToObject.ts
@@ -29,6 +29,9 @@ export function getRelativePositionAndRotationRelativeToObject(
 
   tempRotationEuler.setFromQuaternion(tempRotationQuaternion);
 
+  // Correct for the container's local scale
+  tempPositionVector.multiply(container.scale);
+
   return {
     position: {
       x: tempPositionVector.x,


### PR DESCRIPTION
This PR:
* Fixes an issue where collision events reported to MML documents did not account for the element's local scale (e.g. `width`)
* Fixes an issue where the collision position was reported as the point on the line at the centre of the capsule representing the user. It now reports the position as the point of contact where the capsule touches the surface of the colliding element.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
