### PR TITLE
Fix chat bubble ordering

### DIFF
--- a/packages/3d-web-client-core/src/character/Character.ts
+++ b/packages/3d-web-client-core/src/character/Character.ts
@@ -165,7 +165,7 @@ export class Character extends Group {
       color: new Color(0.125, 0.125, 0.125),
     });
     this.add(tooltip);
-    this.chatTooltips.push(tooltip);
+    this.chatTooltips.unshift(tooltip);
     tooltip.setText(message, () => {
       this.chatTooltips = this.chatTooltips.filter((t) => t !== tooltip);
       this.remove(tooltip);


### PR DESCRIPTION
Fixes chat ordering so that new messages are at the bottom of the vertical stack above an avatar's head.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix