### PR TITLE
fixes ambient occlusion bug (#141)

### DIFF
--- a/packages/3d-web-client-core/src/rendering/post-effects/n8-ssao/EffectCompositer.ts
+++ b/packages/3d-web-client-core/src/rendering/post-effects/n8-ssao/EffectCompositer.ts
@@ -119,10 +119,14 @@ const EffectCompositer = {
       vec4 clipSpacePosition = vec4(coord * 2.0 - 1.0, z, 1.0);
       vec4 viewSpacePosition = projectionMatrixInv * clipSpacePosition;
 
-      vec4 worldSpacePosition = viewSpacePosition;
-      worldSpacePosition.xyz /= worldSpacePosition.w;
-      return worldSpacePosition.xyz;
+      if (abs(viewSpacePosition.w) < 1e-6) {
+        discard;
+      }
+
+      viewSpacePosition /= viewSpacePosition.w;
+      return (viewMatrixInv * viewSpacePosition).xyz;
     }
+
 
     vec3 computeNormal(vec3 worldPos, vec2 vUv) {
       ivec2 p = ivec2(vUv * resolution);

--- a/packages/3d-web-client-core/src/rendering/post-effects/n8-ssao/N8SSAOPass.ts
+++ b/packages/3d-web-client-core/src/rendering/post-effects/n8-ssao/N8SSAOPass.ts
@@ -23,7 +23,6 @@ import {
   Uniform,
   Vector2,
   Vector3,
-  WebGLMultipleRenderTargets,
   WebGLRenderTarget,
   WebGLRenderer,
 } from "three";
@@ -118,7 +117,7 @@ class N8SSAOPass extends Pass {
   private writeTargetInternal: WebGLRenderTarget;
   private readTargetInternal: WebGLRenderTarget;
   private outputTargetInternal: WebGLRenderTarget;
-  private depthDownsampleTarget: WebGLMultipleRenderTargets | null;
+  private depthDownsampleTarget: WebGLRenderTarget | null;
 
   private depthDownsampleQuad: FullScreenTriangle | null;
   private effectShaderQuad: FullScreenTriangle | null;
@@ -227,22 +226,18 @@ class N8SSAOPass extends Pass {
 
   private configureHalfResTargets(): void {
     if (this.configuration.halfRes) {
-      this.depthDownsampleTarget = new WebGLMultipleRenderTargets(
-        this.width / 2,
-        this.height / 2,
-        2,
-        {
-          depthBuffer: false,
-        },
-      );
-      this.depthDownsampleTarget.texture[0].format = RedFormat;
-      this.depthDownsampleTarget.texture[0].type = FloatType;
-      this.depthDownsampleTarget.texture[0].minFilter = NearestFilter;
-      this.depthDownsampleTarget.texture[0].magFilter = NearestFilter;
-      this.depthDownsampleTarget.texture[1].format = RGBAFormat;
-      this.depthDownsampleTarget.texture[1].type = HalfFloatType;
-      this.depthDownsampleTarget.texture[1].minFilter = NearestFilter;
-      this.depthDownsampleTarget.texture[1].magFilter = NearestFilter;
+      this.depthDownsampleTarget = new WebGLRenderTarget(this.width / 2, this.height / 2, {
+        count: 2,
+        depthBuffer: false,
+      });
+      this.depthDownsampleTarget.textures[0].format = RedFormat;
+      this.depthDownsampleTarget.textures[0].type = FloatType;
+      this.depthDownsampleTarget.textures[0].minFilter = NearestFilter;
+      this.depthDownsampleTarget.textures[0].magFilter = NearestFilter;
+      this.depthDownsampleTarget.textures[1].format = RGBAFormat;
+      this.depthDownsampleTarget.textures[1].type = HalfFloatType;
+      this.depthDownsampleTarget.textures[1].minFilter = NearestFilter;
+      this.depthDownsampleTarget.textures[1].magFilter = NearestFilter;
       this.depthDownsampleQuad = new FullScreenTriangle(new ShaderMaterial(DepthDownSample));
     } else {
       if (this.depthDownsampleTarget) {
@@ -439,10 +434,10 @@ class N8SSAOPass extends Pass {
 
     effectShaderUniforms.sceneDiffuse.value = inputBuffer.texture;
     effectShaderUniforms.sceneDepth.value = this.configuration.halfRes
-      ? this.depthDownsampleTarget!.texture[0]
+      ? this.depthDownsampleTarget!.textures[0]
       : this.depthTexture;
     effectShaderUniforms.sceneNormal.value = this.configuration.halfRes
-      ? this.depthDownsampleTarget!.texture[1]
+      ? this.depthDownsampleTarget!.textures[1]
       : null;
     effectShaderUniforms.projMat.value = this.camera.projectionMatrix;
     effectShaderUniforms.viewMat.value = this.camera.matrixWorldInverse;
@@ -486,7 +481,7 @@ class N8SSAOPass extends Pass {
       ];
       poissonBlurUniforms.tDiffuse.value = this.readTargetInternal.texture;
       poissonBlurUniforms.sceneDepth.value = this.configuration.halfRes
-        ? this.depthDownsampleTarget!.texture[0]
+        ? this.depthDownsampleTarget!.textures[0]
         : this.depthTexture;
       poissonBlurUniforms.projMat.value = this.camera.projectionMatrix;
       poissonBlurUniforms.viewMat.value = this.camera.matrixWorldInverse;
@@ -529,7 +524,7 @@ class N8SSAOPass extends Pass {
     effectCompositerUniforms.logDepth.value = renderer.capabilities.logarithmicDepthBuffer;
     effectCompositerUniforms.ortho.value = this.camera instanceof OrthographicCamera;
     effectCompositerUniforms.downsampledDepth.value = this.configuration.halfRes
-      ? this.depthDownsampleTarget!.texture[0]
+      ? this.depthDownsampleTarget!.textures[0]
       : this.depthTexture;
     effectCompositerUniforms.resolution.value = this.r;
     effectCompositerUniforms.blueNoise.value = this.bluenoise;


### PR DESCRIPTION
Fixes #141 

This PR fixes a bug that affected the ambient occlusion in positions far from the scene origin `(0, 0, 0)` due to improper calculations on the depth -> clip-space -> view-space -> world-space conversions on the `getWorldPos` function of the post-processing effect's shader.

With this fix, as seen in the video below, the ambient occlusion works correctly according to the scene's fog and in regions very distant from the scene's origin.

https://github.com/user-attachments/assets/e480e5de-c9bd-40e9-8733-98d7d373215b

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] The title references the corresponding issue # (if relevant)
