### PR TITLE
fixes MML document serving on Windows

### DIFF
--- a/packages/3d-web-experience-server/src/MMLDocumentsServer.ts
+++ b/packages/3d-web-experience-server/src/MMLDocumentsServer.ts
@@ -26,7 +26,7 @@ export class MMLDocumentsServer {
     private directory: string,
     watchPattern: string,
   ) {
-    this.watchPattern = path.resolve(directory, watchPattern);
+    this.watchPattern = watchPattern;
     this.watch();
   }
 


### PR DESCRIPTION
This PR fixes the MML document serving on the `3d-web-experience-server` package on Windows.

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
