### PR TITLE
Fixes to avoid avatar getting stuck in geometry

### DIFF
--- a/packages/3d-web-client-core/src/time/TimeManager.ts
+++ b/packages/3d-web-client-core/src/time/TimeManager.ts
@@ -21,8 +21,13 @@ export class TimeManager {
   public fps: number = 0;
   public averageFPS: number = 0;
 
+  public static maxDeltaTime = 0.1; // 100ms
+
   update() {
     this.rawDeltaTime = this.clock.getDelta();
+    if (this.rawDeltaTime > TimeManager.maxDeltaTime) {
+      this.rawDeltaTime = TimeManager.maxDeltaTime;
+    }
     this.frame++;
     this.time += this.rawDeltaTime;
     this.deltaTimes.push(this.rawDeltaTime);


### PR DESCRIPTION
* Limits delta time to 0.1s to avoid any long ticks from causing large movements that cause missed collisions
* Performs a raycast through the player capsule (top to bottom) to find if any geometry is clipping through the avatar and then moves the avatar up to the point of the collision to escape the geometry.

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix