### PR TITLE
Close hanging websockets on timeout

### DIFF
--- a/packages/3d-web-text-chat/src/chat-network/ReconnectingWebsocket.ts
+++ b/packages/3d-web-text-chat/src/chat-network/ReconnectingWebsocket.ts
@@ -76,10 +76,11 @@ export abstract class ReconnectingWebSocket {
 
   private createWebsocketWithTimeout(timeout: number): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
+      const websocket = this.websocketFactory(this.url);
       const timeoutId = setTimeout(() => {
         reject(new Error("websocket connection timed out"));
+        websocket.close();
       }, timeout);
-      const websocket = this.websocketFactory(this.url);
       websocket.binaryType = "arraybuffer";
       websocket.addEventListener("open", () => {
         clearTimeout(timeoutId);

--- a/packages/3d-web-user-networking/src/ReconnectingWebSocket.ts
+++ b/packages/3d-web-user-networking/src/ReconnectingWebSocket.ts
@@ -91,10 +91,11 @@ export abstract class ReconnectingWebSocket {
 
   private createWebsocketWithTimeout(timeout: number): Promise<WebSocket> {
     return new Promise((resolve, reject) => {
+      const websocket = this.websocketFactory(this.url);
       const timeoutId = setTimeout(() => {
         reject(new Error("websocket connection timed out"));
+        websocket.close();
       }, timeout);
-      const websocket = this.websocketFactory(this.url);
       websocket.binaryType = "arraybuffer";
       websocket.addEventListener("open", () => {
         clearTimeout(timeoutId);


### PR DESCRIPTION
This PR fixes an issue where websockets that were opened to connect to a server, but were abandoned because of a timeout would stay open, but unused.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix

**Does your PR introduce a breaking change?** (check one)

- [x] No

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
