### PR TITLE
fixes the scene bloom live-update

### DIFF
--- a/packages/3d-web-client-core/src/rendering/composer.ts
+++ b/packages/3d-web-client-core/src/rendering/composer.ts
@@ -327,6 +327,7 @@ export class Composer {
 
     this.updateSkyboxAndEnvValues();
     this.updateAmbientLightValues();
+    this.updateBloomValues();
     this.updateSunValues();
     this.updateFogValues();
   }
@@ -619,6 +620,13 @@ export class Composer {
       envValues.skyboxPolarAngle = this.environmentConfiguration?.skybox.polarAngle;
       this.updateSkyboxRotation();
     }
+  }
+
+  private updateBloomValues() {
+    if (typeof this.environmentConfiguration?.postProcessing?.bloomIntensity === "number") {
+      extrasValues.bloom = this.environmentConfiguration.postProcessing.bloomIntensity;
+    }
+    this.bloomEffect.intensity = extrasValues.bloom;
   }
 
   private updateAmbientLightValues() {


### PR DESCRIPTION
Resolves #212 

This PR aims to expose the bloom settings through the `updateEnvironmentConfiguration` public method so it can be live-updated from applications that consume/embed the `3d-web-client-core` the same way other environment settings are. 

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)
