### PR TITLE
fix: correctly load HDRI background/environment

### DIFF
--- a/packages/3d-web-standalone-avatar-editor/src/AvatarRenderer.ts
+++ b/packages/3d-web-standalone-avatar-editor/src/AvatarRenderer.ts
@@ -4,17 +4,16 @@ import {
   AnimationClip,
   AnimationMixer,
   Bone,
+  EquirectangularReflectionMapping,
   LinearSRGBColorSpace,
   LoadingManager,
   LoopRepeat,
   Object3D,
-  PMREMGenerator,
   Scene,
   VSMShadowMap,
   Vector3,
   WebGLRenderer,
 } from "three";
-import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
 
 import { Lights } from "./scene/Lights";
@@ -98,18 +97,15 @@ export class AvatarRenderer {
 
   public useHDRI(url: string): void {
     if (!this.renderer) return;
-    const pmremGenerator = new PMREMGenerator(this.renderer);
     new RGBELoader(new LoadingManager()).load(
       url,
       (texture) => {
-        const envMap = pmremGenerator!.fromEquirectangular(texture).texture;
-        if (envMap) {
-          envMap.colorSpace = LinearSRGBColorSpace;
-          envMap.needsUpdate = true;
-          this.scene.environment = envMap;
-          texture.dispose();
-          pmremGenerator!.dispose();
-        }
+        texture.mapping = EquirectangularReflectionMapping;
+        texture.colorSpace = LinearSRGBColorSpace;
+        texture.needsUpdate = true;
+        this.scene.environment = texture;
+        this.scene.background = texture;
+        texture.dispose();
       },
       () => {},
       (error: ErrorEvent) => {

--- a/packages/3d-web-standalone-avatar-editor/src/screenshot/ModelScreenshotter.ts
+++ b/packages/3d-web-standalone-avatar-editor/src/screenshot/ModelScreenshotter.ts
@@ -2,18 +2,17 @@ import { ModelLoader } from "@mml-io/model-loader";
 import {
   AnimationMixer,
   Box3,
+  EquirectangularReflectionMapping,
   LinearSRGBColorSpace,
   LoadingManager,
   Object3D,
   PerspectiveCamera,
-  PMREMGenerator,
   Scene,
   Vector3,
   VSMShadowMap,
   WebGLRenderer,
   WebGLRenderTarget,
 } from "three";
-import { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
 
 import { getDataUrlFromRenderTarget } from "./getDataUrlFromRenderTarget";
@@ -87,13 +86,12 @@ export class ModelScreenshotter {
         new RGBELoader(new LoadingManager()).load(
           this.hdrURL!,
           (texture) => {
-            const pmremGenerator = new PMREMGenerator(this.renderer);
-            const envMap = pmremGenerator.fromEquirectangular(texture).texture;
-            envMap.colorSpace = LinearSRGBColorSpace;
-            envMap.needsUpdate = true;
-            this.scene.environment = envMap;
+            texture.mapping = EquirectangularReflectionMapping;
+            texture.colorSpace = LinearSRGBColorSpace;
+            texture.needsUpdate = true;
+            this.scene.environment = texture;
+            this.scene.background = texture;
             texture.dispose();
-            pmremGenerator.dispose();
             resolve();
           },
           undefined,


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Please add a detailed description of what your PR addresses below and complete the following questions.

Before submitting, please review the contributor guidelines: https://github.com/mml-io/3d-web-experience/blob/main/CONTRIBUTING.md.
-->

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [ ] The title references the corresponding issue # (if relevant)

Updated loading of HDR images to match recommended by THREE.js examples

## Before changes
![Screenshot 2025-04-28 at 16 42 37](https://github.com/user-attachments/assets/79d91142-8b66-42dd-ad93-d9ffad3ccf66)


## After changes
![Screenshot 2025-04-28 at 16 42 02](https://github.com/user-attachments/assets/e703c36d-9966-4cac-a4ad-390be6944cd4)

