### PR TITLE
implements (re)spawn configurable settings

### DIFF
--- a/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
@@ -10,6 +10,7 @@ import {
   GroundPlane,
   KeyInputManager,
   MMLCompositionScene,
+  SpawnConfiguration,
   TimeManager,
 } from "@mml-io/3d-web-client-core";
 import { MMLWebRunnerClient } from "@mml-io/mml-web-runner";
@@ -67,11 +68,14 @@ export class LocalAvatarClient {
   private documentRunnerClients = new Set<MMLWebRunnerClient>();
   private animationFrameRequest: number | null = null;
 
+  private spawnConfiguration: SpawnConfiguration;
+
   constructor(
     private localAvatarServer: LocalAvatarServer,
     private localClientId: number,
     spawnPosition: Vector3,
     spawnRotation: Euler,
+    spawnConfiguration: SpawnConfiguration,
   ) {
     this.element = document.createElement("div");
     this.element.style.position = "absolute";
@@ -122,6 +126,29 @@ export class LocalAvatarClient {
       },
     );
 
+    this.spawnConfiguration = {
+      spawnPosition: {
+        x: spawnConfiguration?.spawnPosition?.x ?? 0,
+        y: spawnConfiguration?.spawnPosition?.y ?? 0,
+        z: spawnConfiguration?.spawnPosition?.z ?? 0,
+      },
+      spawnPositionvariance: {
+        x: spawnConfiguration?.spawnPositionvariance?.x ?? 0,
+        y: spawnConfiguration?.spawnPositionvariance?.y ?? 0,
+        z: spawnConfiguration?.spawnPositionvariance?.z ?? 0,
+      },
+      spawnYRotation: spawnConfiguration?.spawnYRotation ?? 0,
+      respawnTrigger: {
+        minX: spawnConfiguration?.respawnTrigger?.minX,
+        maxX: spawnConfiguration?.respawnTrigger?.maxX,
+        minY: spawnConfiguration?.respawnTrigger?.minY ?? -100,
+        maxY: spawnConfiguration?.respawnTrigger?.maxY,
+        minZ: spawnConfiguration?.respawnTrigger?.minZ,
+        maxZ: spawnConfiguration?.respawnTrigger?.maxZ,
+      },
+      enableRespawnButton: spawnConfiguration?.enableRespawnButton ?? false,
+    };
+
     this.characterManager = new CharacterManager({
       composer: this.composer,
       characterModelLoader: this.characterModelLoader,
@@ -137,6 +164,7 @@ export class LocalAvatarClient {
       characterResolve: () => {
         return { username: "User", characterDescription };
       },
+      spawnConfiguration: this.spawnConfiguration,
     });
     this.scene.add(this.characterManager.group);
 

--- a/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
@@ -73,8 +73,6 @@ export class LocalAvatarClient {
   constructor(
     private localAvatarServer: LocalAvatarServer,
     private localClientId: number,
-    spawnPosition: Vector3,
-    spawnRotation: Euler,
     spawnConfiguration: SpawnConfiguration,
   ) {
     this.element = document.createElement("div");
@@ -185,6 +183,16 @@ export class LocalAvatarClient {
     this.collisionsManager.addMeshesGroup(groundPlane);
     this.scene.add(groundPlane);
 
+    const spawnPosition = new Vector3(
+      this.spawnConfiguration.spawnPosition!.x,
+      this.spawnConfiguration.spawnPosition!.y,
+      this.spawnConfiguration.spawnPosition!.z,
+    );
+    const spawnRotation = new Euler(
+      0,
+      this.spawnConfiguration.spawnYRotation! * (Math.PI / 180),
+      0,
+    );
     this.characterManager.spawnLocalCharacter(
       localClientId,
       "User",
@@ -192,6 +200,19 @@ export class LocalAvatarClient {
       spawnPosition,
       spawnRotation,
     );
+
+    let cameraPosition: Vector3 | null = null;
+    const offset = new Vector3(0, 0, 3.3);
+    offset.applyEuler(new Euler(0, spawnRotation.y, 0));
+    cameraPosition = spawnPosition.clone().sub(offset).add(this.characterManager.headTargetOffset);
+
+    if (cameraPosition !== null) {
+      this.cameraManager.camera.position.copy(cameraPosition);
+      this.cameraManager.setTarget(
+        new Vector3().add(spawnPosition).add(this.characterManager.headTargetOffset),
+      );
+      this.cameraManager.reverseUpdateFromPositions();
+    }
   }
 
   public dispose() {

--- a/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
@@ -10,7 +10,7 @@ import {
   GroundPlane,
   KeyInputManager,
   MMLCompositionScene,
-  SpawnConfiguration,
+  SpawnConfigurationState,
   TimeManager,
 } from "@mml-io/3d-web-client-core";
 import { MMLWebRunnerClient } from "@mml-io/mml-web-runner";
@@ -68,12 +68,12 @@ export class LocalAvatarClient {
   private documentRunnerClients = new Set<MMLWebRunnerClient>();
   private animationFrameRequest: number | null = null;
 
-  private spawnConfiguration: SpawnConfiguration;
+  private spawnConfiguration: SpawnConfigurationState;
 
   constructor(
     private localAvatarServer: LocalAvatarServer,
     private localClientId: number,
-    spawnConfiguration: SpawnConfiguration,
+    spawnConfiguration: SpawnConfigurationState,
   ) {
     this.element = document.createElement("div");
     this.element.style.position = "absolute";
@@ -130,10 +130,10 @@ export class LocalAvatarClient {
         y: spawnConfiguration?.spawnPosition?.y ?? 0,
         z: spawnConfiguration?.spawnPosition?.z ?? 0,
       },
-      spawnPositionvariance: {
-        x: spawnConfiguration?.spawnPositionvariance?.x ?? 0,
-        y: spawnConfiguration?.spawnPositionvariance?.y ?? 0,
-        z: spawnConfiguration?.spawnPositionvariance?.z ?? 0,
+      spawnPositionVariance: {
+        x: spawnConfiguration?.spawnPositionVariance?.x ?? 0,
+        y: spawnConfiguration?.spawnPositionVariance?.y ?? 0,
+        z: spawnConfiguration?.spawnPositionVariance?.z ?? 0,
       },
       spawnYRotation: spawnConfiguration?.spawnYRotation ?? 0,
       respawnTrigger: {

--- a/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/LocalAvatarClient.ts
@@ -166,6 +166,10 @@ export class LocalAvatarClient {
     });
     this.scene.add(this.characterManager.group);
 
+    if (spawnConfiguration.enableRespawnButton) {
+      this.element.appendChild(this.characterManager.createRespawnButton());
+    }
+
     this.mmlComposition = new MMLCompositionScene({
       targetElement: this.element,
       renderer: this.composer.renderer,

--- a/example/local-only-multi-user-3d-web-experience/client/src/index.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/index.ts
@@ -1,4 +1,4 @@
-import { SpawnConfiguration } from "@mml-io/3d-web-client-core";
+import { SpawnConfigurationState } from "@mml-io/3d-web-client-core";
 import { IframeWrapper, MMLScene, registerCustomElementsToWindow } from "@mml-io/mml-web";
 import {
   EditableNetworkedDOM,
@@ -46,13 +46,27 @@ window.addEventListener("DOMContentLoaded", async () => {
   // Create a "local" server that the avatar clients can connect to to see each other
   const localAvatarServer = new LocalAvatarServer();
 
-  const client1SpawnConfig: SpawnConfiguration = {
+  const client1SpawnConfig: SpawnConfigurationState = {
     spawnPosition: {
       x: -0.5,
       y: 0.5,
       z: 5,
     },
+    spawnPositionVariance: {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
+    respawnTrigger: {
+      minX: Number.NEGATIVE_INFINITY,
+      maxX: Number.POSITIVE_INFINITY,
+      minY: -100,
+      maxY: Number.POSITIVE_INFINITY,
+      minZ: Number.NEGATIVE_INFINITY,
+      maxZ: Number.POSITIVE_INFINITY,
+    },
     spawnYRotation: 180,
+    enableRespawnButton: false,
   };
 
   // Create the first avatar client and append it to the first quadrant
@@ -61,13 +75,27 @@ window.addEventListener("DOMContentLoaded", async () => {
   quadrant1.appendChild(client1.element);
   client1.update();
 
-  const client2SpawnConfig: SpawnConfiguration = {
+  const client2SpawnConfig: SpawnConfigurationState = {
     spawnPosition: {
       x: 0.5,
       y: 0.5,
       z: 5,
     },
+    spawnPositionVariance: {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
     spawnYRotation: 180,
+    respawnTrigger: {
+      minX: Number.NEGATIVE_INFINITY,
+      maxX: Number.POSITIVE_INFINITY,
+      minY: -100,
+      maxY: Number.POSITIVE_INFINITY,
+      minZ: Number.NEGATIVE_INFINITY,
+      maxZ: Number.POSITIVE_INFINITY,
+    },
+    enableRespawnButton: false,
   };
 
   // Create the second avatar client and append it to the second quadrant

--- a/example/local-only-multi-user-3d-web-experience/client/src/index.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/index.ts
@@ -9,7 +9,6 @@ import {
   StandaloneThreeJSAdapter,
   StandaloneThreeJSAdapterControlsType,
 } from "@mml-io/mml-web-threejs-standalone";
-import { Euler, Vector3 } from "three";
 
 import exampleMMLDocumentHTML from "./example-mml.html";
 import { LocalAvatarClient } from "./LocalAvatarClient";
@@ -53,16 +52,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       y: 0.5,
       z: 5,
     },
+    spawnYRotation: 180,
   };
 
   // Create the first avatar client and append it to the first quadrant
-  const client1 = new LocalAvatarClient(
-    localAvatarServer,
-    1,
-    new Vector3(-0.5, 0.5, 5),
-    new Euler(0, Math.PI, 0),
-    client1SpawnConfig,
-  );
+  const client1 = new LocalAvatarClient(localAvatarServer, 1, client1SpawnConfig);
   client1.addDocument(networkedDOMDocument, iframeWindow, iframeBody);
   quadrant1.appendChild(client1.element);
   client1.update();
@@ -73,16 +67,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       y: 0.5,
       z: 5,
     },
+    spawnYRotation: 180,
   };
 
   // Create the second avatar client and append it to the second quadrant
-  const client2 = new LocalAvatarClient(
-    localAvatarServer,
-    2,
-    new Vector3(0.5, 0.5, 5),
-    new Euler(0, Math.PI, 0),
-    client2SpawnConfig,
-  );
+  const client2 = new LocalAvatarClient(localAvatarServer, 2, client2SpawnConfig);
   client2.addDocument(networkedDOMDocument, iframeWindow, iframeBody);
   quadrant2.appendChild(client2.element);
   client2.update();

--- a/example/local-only-multi-user-3d-web-experience/client/src/index.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/index.ts
@@ -66,7 +66,7 @@ window.addEventListener("DOMContentLoaded", async () => {
       maxZ: Number.POSITIVE_INFINITY,
     },
     spawnYRotation: 180,
-    enableRespawnButton: false,
+    enableRespawnButton: true,
   };
 
   // Create the first avatar client and append it to the first quadrant

--- a/example/local-only-multi-user-3d-web-experience/client/src/index.ts
+++ b/example/local-only-multi-user-3d-web-experience/client/src/index.ts
@@ -1,3 +1,4 @@
+import { SpawnConfiguration } from "@mml-io/3d-web-client-core";
 import { IframeWrapper, MMLScene, registerCustomElementsToWindow } from "@mml-io/mml-web";
 import {
   EditableNetworkedDOM,
@@ -46,16 +47,33 @@ window.addEventListener("DOMContentLoaded", async () => {
   // Create a "local" server that the avatar clients can connect to to see each other
   const localAvatarServer = new LocalAvatarServer();
 
+  const client1SpawnConfig: SpawnConfiguration = {
+    spawnPosition: {
+      x: -0.5,
+      y: 0.5,
+      z: 5,
+    },
+  };
+
   // Create the first avatar client and append it to the first quadrant
   const client1 = new LocalAvatarClient(
     localAvatarServer,
     1,
     new Vector3(-0.5, 0.5, 5),
     new Euler(0, Math.PI, 0),
+    client1SpawnConfig,
   );
   client1.addDocument(networkedDOMDocument, iframeWindow, iframeBody);
   quadrant1.appendChild(client1.element);
   client1.update();
+
+  const client2SpawnConfig: SpawnConfiguration = {
+    spawnPosition: {
+      x: 0.5,
+      y: 0.5,
+      z: 5,
+    },
+  };
 
   // Create the second avatar client and append it to the second quadrant
   const client2 = new LocalAvatarClient(
@@ -63,6 +81,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     2,
     new Vector3(0.5, 0.5, 5),
     new Euler(0, Math.PI, 0),
+    client2SpawnConfig,
   );
   client2.addDocument(networkedDOMDocument, iframeWindow, iframeBody);
   quadrant2.appendChild(client2.element);

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -34,17 +34,6 @@ const app = new Networked3dWebExperienceClient(holder, {
   avatarConfiguration: {
     availableAvatars: [],
   },
-  spawnConfiguration: {
-    spawnPosition: {
-      y: 5,
-    },
-    spawnPositionVariance: {
-      x: 2,
-      y: 5,
-      z: 1,
-    },
-    enableRespawnButton: true,
-  },
   allowOrbitalCamera: true,
   loadingScreen: {
     background: "#424242",

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -32,7 +32,12 @@ const app = new Networked3dWebExperienceClient(holder, {
     },
   },
   avatarConfiguration: {
-    availableAvatars: [],
+    availableAvatars: [
+      {
+        name: "bot",
+        meshFileUrl: "/assets/models/bot.glb",
+      },
+    ],
   },
   allowOrbitalCamera: true,
   loadingScreen: {
@@ -42,6 +47,9 @@ const app = new Networked3dWebExperienceClient(holder, {
     backgroundBlurAmount: 12,
     title: "3D Web Experience",
     subtitle: "Powered by Metaverse Markup Language",
+  },
+  spawnConfiguration: {
+    enableRespawnButton: true,
   },
 });
 

--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -34,6 +34,17 @@ const app = new Networked3dWebExperienceClient(holder, {
   avatarConfiguration: {
     availableAvatars: [],
   },
+  spawnConfiguration: {
+    spawnPosition: {
+      y: 5,
+    },
+    spawnPositionVariance: {
+      x: 2,
+      y: 5,
+      z: 1,
+    },
+    enableRespawnButton: true,
+  },
   allowOrbitalCamera: true,
   loadingScreen: {
     background: "#424242",

--- a/packages/3d-web-avatar-selection-ui/src/avatar-selection-ui/components/AvatarPanel/AvatarSelectionUIComponent.module.css
+++ b/packages/3d-web-avatar-selection-ui/src/avatar-selection-ui/components/AvatarPanel/AvatarSelectionUIComponent.module.css
@@ -1,9 +1,9 @@
 .menuButton {
   width: 70px;
   min-height: 70px;
-  position: fixed;
-  top: 12px;
-  right: 12px;
+  position: absolute;
+  top: 0px;
+  right: 0px;
   z-index: 102;
   user-select: none;
 }
@@ -27,7 +27,7 @@
   border-radius: 50%;
   width: 44px;
   height: 44px;
-  position: fixed;
+  position: absolute;
   top: 12px;
   right: 12px;
   border: 1px solid rgba(255, 255, 255, 0.21);
@@ -42,7 +42,7 @@
   border-radius: 50%;
   width: 42px;
   height: 42px;
-  position: fixed;
+  position: absolute;
   top: 12px;
   right: 12px;
   border: 1px solid rgba(255, 255, 255, 0.21);
@@ -64,11 +64,11 @@
 }
 
 .avatarSelectionContainer {
-  position: fixed;
+  position: absolute;
   top: 11px;
   right: 60px;
   width: 30%;
-  min-width: 290px;
+  min-width: 250px;
   max-width: 720px;
   max-height: calc(100vh - 22px);
   background: #000000b3;

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -16,27 +16,41 @@ import { LocalController } from "./LocalController";
 import { RemoteController } from "./RemoteController";
 import { encodeCharacterAndCamera } from "./url-position";
 
+type SpawnPosition = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+type SpawnPositionVariance = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+type RespawnTrigger = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
+};
+
 export type SpawnConfiguration = {
-  spawnPosition?: {
-    x: number;
-    y: number;
-    z: number;
-  };
-  spawnPositionvariance?: {
-    x: number;
-    y: number;
-    z: number;
-  };
+  spawnPosition?: Partial<SpawnPosition>;
+  spawnPositionVariance?: Partial<SpawnPositionVariance>;
   spawnYRotation?: number;
-  respawnTrigger?: {
-    minX?: number;
-    maxX?: number;
-    minY?: number;
-    maxY?: number;
-    minZ?: number;
-    maxZ?: number;
-  };
+  respawnTrigger?: Partial<RespawnTrigger>;
   enableRespawnButton?: boolean;
+};
+
+export type SpawnConfigurationState = {
+  spawnPosition: SpawnPosition;
+  spawnPositionVariance: SpawnPositionVariance;
+  spawnYRotation: number;
+  respawnTrigger: RespawnTrigger;
+  enableRespawnButton: boolean;
 };
 
 export type CharacterManagerConfig = {
@@ -50,7 +64,7 @@ export type CharacterManagerConfig = {
   remoteUserStates: Map<number, CharacterState>;
   sendUpdate: (update: CharacterState) => void;
   animationConfig: AnimationConfig;
-  spawnConfiguration: SpawnConfiguration;
+  spawnConfiguration: SpawnConfigurationState;
   characterResolve: (clientId: number) => {
     username: string;
     characterDescription: CharacterDescription;

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -89,8 +89,6 @@ export class CharacterManager {
   public readonly group: Group;
   private lastUpdateSentTime: number = 0;
 
-  private respawnButton: HTMLDivElement | null = null;
-
   constructor(private config: CharacterManagerConfig) {
     this.group = new Group();
   }
@@ -142,32 +140,33 @@ export class CharacterManager {
     this.localCharacter.rotation.set(spawnRotation.x, spawnRotation.y, spawnRotation.z);
     this.group.add(character);
     this.localCharacterSpawned = true;
-    if (this.config.spawnConfiguration.enableRespawnButton) {
-      this.setupRespawnButton();
-    }
   }
 
-  private setupRespawnButton() {
-    this.respawnButton = document.createElement("div");
-    this.respawnButton.className = "respawn-button";
-    this.respawnButton.innerText = "RESPAWN";
-    this.respawnButton.onclick = () => {
+  public createRespawnButton(): HTMLDivElement {
+    const respawnButton = document.createElement("div");
+    respawnButton.className = "respawn-button";
+    respawnButton.textContent = "RESPAWN";
+    respawnButton.addEventListener("click", () => {
       this.localController.resetPosition();
-    };
-    this.respawnButton.style.position = "absolute";
-    this.respawnButton.style.bottom = "12px";
-    this.respawnButton.style.right = "12px";
-    this.respawnButton.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
-    this.respawnButton.style.color = "#dddddd";
-    this.respawnButton.style.padding = "7px";
-    this.respawnButton.style.borderRadius = "7px";
-    this.respawnButton.style.cursor = "pointer";
-    this.respawnButton.style.zIndex = "1000";
-    this.respawnButton.style.fontSize = "12px";
-    this.respawnButton.style.fontFamily = "Arial, sans-serif";
-    this.respawnButton.style.fontWeight = "bold";
-    this.respawnButton.style.userSelect = "none";
-    document.body.appendChild(this.respawnButton);
+    });
+    respawnButton.style.position = "absolute";
+    respawnButton.style.top = "14px";
+    respawnButton.style.left = "8px";
+    respawnButton.style.zIndex = "102";
+    respawnButton.style.backgroundColor = "rgba(0, 0, 0, 0.7)";
+    respawnButton.style.color = "#ffffff";
+    respawnButton.style.borderRadius = "8px";
+    respawnButton.style.border = "1px solid rgba(255, 255, 255, 0.21)";
+    respawnButton.style.height = "22px";
+    respawnButton.style.padding = "8px";
+    respawnButton.style.cursor = "pointer";
+    respawnButton.style.fontSize = "12px";
+    respawnButton.style.fontFamily = "Helvetica, sans-serif";
+    respawnButton.style.userSelect = "none";
+    respawnButton.style.display = "flex";
+    respawnButton.style.alignItems = "center";
+    respawnButton.style.justifyContent = "center";
+    return respawnButton;
   }
 
   public setupTweakPane(tweakPane: TweakPane) {

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -16,6 +16,29 @@ import { LocalController } from "./LocalController";
 import { RemoteController } from "./RemoteController";
 import { encodeCharacterAndCamera } from "./url-position";
 
+export type SpawnConfiguration = {
+  spawnPosition?: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  spawnPositionvariance?: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  spawnYRotation?: number;
+  respawnTrigger?: {
+    minX?: number;
+    maxX?: number;
+    minY?: number;
+    maxY?: number;
+    minZ?: number;
+    maxZ?: number;
+  };
+  enableRespawnButton?: boolean;
+};
+
 export type CharacterManagerConfig = {
   composer: Composer;
   characterModelLoader: CharacterModelLoader;
@@ -27,6 +50,7 @@ export type CharacterManagerConfig = {
   remoteUserStates: Map<number, CharacterState>;
   sendUpdate: (update: CharacterState) => void;
   animationConfig: AnimationConfig;
+  spawnConfiguration: SpawnConfiguration;
   characterResolve: (clientId: number) => {
     username: string;
     characterDescription: CharacterDescription;
@@ -50,6 +74,8 @@ export class CharacterManager {
 
   public readonly group: Group;
   private lastUpdateSentTime: number = 0;
+
+  private respawnButton: HTMLDivElement | null = null;
 
   constructor(private config: CharacterManagerConfig) {
     this.group = new Group();
@@ -96,11 +122,38 @@ export class CharacterManager {
       virtualJoystick: this.config.virtualJoystick,
       cameraManager: this.config.cameraManager,
       timeManager: this.config.timeManager,
+      spawnConfiguration: this.config.spawnConfiguration,
     });
     this.localCharacter.position.set(spawnPosition.x, spawnPosition.y, spawnPosition.z);
     this.localCharacter.rotation.set(spawnRotation.x, spawnRotation.y, spawnRotation.z);
     this.group.add(character);
     this.localCharacterSpawned = true;
+    if (this.config.spawnConfiguration.enableRespawnButton) {
+      this.setupRespawnButton();
+    }
+  }
+
+  private setupRespawnButton() {
+    this.respawnButton = document.createElement("div");
+    this.respawnButton.className = "respawn-button";
+    this.respawnButton.innerText = "RESPAWN";
+    this.respawnButton.onclick = () => {
+      this.localController.resetPosition();
+    };
+    this.respawnButton.style.position = "absolute";
+    this.respawnButton.style.bottom = "12px";
+    this.respawnButton.style.right = "12px";
+    this.respawnButton.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
+    this.respawnButton.style.color = "#dddddd";
+    this.respawnButton.style.padding = "7px";
+    this.respawnButton.style.borderRadius = "7px";
+    this.respawnButton.style.cursor = "pointer";
+    this.respawnButton.style.zIndex = "1000";
+    this.respawnButton.style.fontSize = "12px";
+    this.respawnButton.style.fontFamily = "Arial, sans-serif";
+    this.respawnButton.style.fontWeight = "bold";
+    this.respawnButton.style.userSelect = "none";
+    document.body.appendChild(this.respawnButton);
   }
 
   public setupTweakPane(tweakPane: TweakPane) {

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -8,7 +8,7 @@ import { TimeManager } from "../time/TimeManager";
 import { characterControllerValues } from "../tweakpane/blades/characterControlsFolder";
 
 import { Character } from "./Character";
-import { SpawnConfiguration } from "./CharacterManager";
+import { SpawnConfigurationState } from "./CharacterManager";
 import { AnimationState, CharacterState } from "./CharacterState";
 
 const downVector = new Vector3(0, -1, 0);
@@ -21,7 +21,7 @@ export type LocalControllerConfig = {
   virtualJoystick?: VirtualJoystick;
   cameraManager: CameraManager;
   timeManager: TimeManager;
-  spawnConfiguration: SpawnConfiguration;
+  spawnConfiguration: SpawnConfigurationState;
 };
 
 export class LocalController {
@@ -112,24 +112,24 @@ export class LocalController {
       rotation: { quaternionY: 0, quaternionW: 1 },
       state: AnimationState.idle,
     };
-    this.minimumX = this.config.spawnConfiguration.respawnTrigger?.minX ?? Number.NEGATIVE_INFINITY;
-    this.maximumX = this.config.spawnConfiguration.respawnTrigger?.maxX ?? Number.POSITIVE_INFINITY;
-    this.minimumY = this.config.spawnConfiguration.respawnTrigger?.minY ?? Number.NEGATIVE_INFINITY;
-    this.maximumY = this.config.spawnConfiguration.respawnTrigger?.maxY ?? Number.POSITIVE_INFINITY;
-    this.minimumZ = this.config.spawnConfiguration.respawnTrigger?.minZ ?? Number.NEGATIVE_INFINITY;
-    this.maximumZ = this.config.spawnConfiguration.respawnTrigger?.maxZ ?? Number.POSITIVE_INFINITY;
+    this.minimumX = this.config.spawnConfiguration.respawnTrigger.minX;
+    this.maximumX = this.config.spawnConfiguration.respawnTrigger.maxX;
+    this.minimumY = this.config.spawnConfiguration.respawnTrigger.minY;
+    this.maximumY = this.config.spawnConfiguration.respawnTrigger.maxY;
+    this.minimumZ = this.config.spawnConfiguration.respawnTrigger.minZ;
+    this.maximumZ = this.config.spawnConfiguration.respawnTrigger.maxZ;
 
     const maxAbsSpawnX =
-      Math.abs(this.config.spawnConfiguration.spawnPosition!.x) +
-      Math.abs(this.config.spawnConfiguration.spawnPositionvariance!.x);
+      Math.abs(this.config.spawnConfiguration.spawnPosition.x) +
+      Math.abs(this.config.spawnConfiguration.spawnPositionVariance.x);
 
     const maxAbsSpawnY =
-      Math.abs(this.config.spawnConfiguration.spawnPosition!.y) +
-      Math.abs(this.config.spawnConfiguration.spawnPositionvariance!.y);
+      Math.abs(this.config.spawnConfiguration.spawnPosition.y) +
+      Math.abs(this.config.spawnConfiguration.spawnPositionVariance.y);
 
     const maxAbsSpawnZ =
-      Math.abs(this.config.spawnConfiguration.spawnPosition!.z) +
-      Math.abs(this.config.spawnConfiguration.spawnPositionvariance!.z);
+      Math.abs(this.config.spawnConfiguration.spawnPosition.z) +
+      Math.abs(this.config.spawnConfiguration.spawnPositionVariance.z);
 
     if (Math.abs(this.minimumX) < maxAbsSpawnX || Math.abs(this.maximumX) < maxAbsSpawnX) {
       // If the respawn trigger minX or maxX is out of bounds of the spawn position variance,
@@ -138,7 +138,7 @@ export class LocalController {
       this.minimumX = -maxAbsSpawnX - 1;
       this.maximumX = maxAbsSpawnX + 1;
       console.warn(
-        "The respawnTrigger X values are out of the bounds of the spawnPosition + spawnPositionvariance. Please check your respawnTrigger config.",
+        "The respawnTrigger X values are out of the bounds of the spawnPosition + spawnPositionVariance. Please check your respawnTrigger config.",
       );
     }
 
@@ -146,7 +146,7 @@ export class LocalController {
       this.minimumY = -maxAbsSpawnY - 1;
       this.maximumY = maxAbsSpawnY + 1;
       console.warn(
-        "The respawnTrigger Y values are out of the bounds of the spawnPosition + spawnPositionvariance. Please check your respawnTrigger config.",
+        "The respawnTrigger Y values are out of the bounds of the spawnPosition + spawnPositionVariance. Please check your respawnTrigger config.",
       );
     }
 
@@ -154,9 +154,19 @@ export class LocalController {
       this.minimumZ = -maxAbsSpawnZ - 1;
       this.maximumZ = maxAbsSpawnZ + 1;
       console.warn(
-        "The respawnTrigger Z values are out of the bounds of the spawnPosition + spawnPositionvariance. Please check your respawnTrigger config.",
+        "The respawnTrigger Z values are out of the bounds of the spawnPosition + spawnPositionVariance. Please check your respawnTrigger config.",
       );
     }
+  }
+
+  public updateSpawnConfig(spawnConfig: SpawnConfigurationState): void {
+    this.config.spawnConfiguration = spawnConfig;
+    this.minimumX = spawnConfig.respawnTrigger.minX;
+    this.maximumX = spawnConfig.respawnTrigger.maxX;
+    this.minimumY = spawnConfig.respawnTrigger.minY;
+    this.maximumY = spawnConfig.respawnTrigger.maxY;
+    this.minimumZ = spawnConfig.respawnTrigger.minZ;
+    this.maximumZ = spawnConfig.respawnTrigger.maxZ;
   }
 
   public update(): void {
@@ -562,21 +572,21 @@ export class LocalController {
 
     this.config.character.position.set(
       randomWithVariance(
-        this.config.spawnConfiguration.spawnPosition!.x,
-        this.config.spawnConfiguration.spawnPositionvariance!.x,
+        this.config.spawnConfiguration.spawnPosition.x,
+        this.config.spawnConfiguration.spawnPositionVariance.x,
       ),
       randomWithVariance(
-        this.config.spawnConfiguration.spawnPosition!.y,
-        this.config.spawnConfiguration.spawnPositionvariance!.y,
+        this.config.spawnConfiguration.spawnPosition.y,
+        this.config.spawnConfiguration.spawnPositionVariance.y,
       ),
       randomWithVariance(
-        this.config.spawnConfiguration.spawnPosition!.z,
-        this.config.spawnConfiguration.spawnPositionvariance!.z,
+        this.config.spawnConfiguration.spawnPosition.z,
+        this.config.spawnConfiguration.spawnPositionVariance.z,
       ),
     );
     const respawnRotation = new Euler(
       0,
-      -this.config.spawnConfiguration.spawnYRotation! * (Math.PI / 180),
+      -this.config.spawnConfiguration.spawnYRotation * (Math.PI / 180),
       0,
     );
     this.config.character.rotation.set(respawnRotation.x, respawnRotation.y, respawnRotation.z);

--- a/packages/3d-web-client-core/src/character/RemoteController.ts
+++ b/packages/3d-web-client-core/src/character/RemoteController.ts
@@ -41,8 +41,14 @@ export class RemoteController {
 
   private updateFromNetwork(clientUpdate: CharacterState): void {
     const { position, rotation, state } = clientUpdate;
-    this.config.character.position.lerp(new Vector3(position.x, position.y, position.z), 0.15);
-    const rotationQuaternion = new Quaternion(0, rotation.quaternionY, 0, rotation.quaternionW);
+    const distanceSquared = this.config.character.position.distanceToSquared(position);
+    if (distanceSquared > 5 * 5) {
+      // More than 5m of movement in a tick - the character is likely teleporting rather than just moving quickly - snap to the new position
+      this.config.character.position.copy(position);
+    } else {
+      this.config.character.position.lerp(new Vector3(position.x, position.y, position.z), 0.15);
+    }
+    const rotationQuaternion = tempQuaternion.set(0, rotation.quaternionY, 0, rotation.quaternionW);
     this.config.character.quaternion.slerp(rotationQuaternion, 0.6);
     if (state !== this.currentAnimation) {
       this.currentAnimation = state;

--- a/packages/3d-web-client-core/src/index.ts
+++ b/packages/3d-web-client-core/src/index.ts
@@ -1,6 +1,10 @@
 export { CameraManager } from "./camera/CameraManager";
 export { CharacterDescription, AnimationConfig } from "./character/Character";
-export { CharacterManager, SpawnConfiguration } from "./character/CharacterManager";
+export {
+  CharacterManager,
+  SpawnConfiguration,
+  SpawnConfigurationState,
+} from "./character/CharacterManager";
 export * from "./character/url-position";
 export * from "./helpers/math-helpers";
 export { CharacterModelLoader } from "./character/CharacterModelLoader";

--- a/packages/3d-web-client-core/src/index.ts
+++ b/packages/3d-web-client-core/src/index.ts
@@ -1,6 +1,6 @@
 export { CameraManager } from "./camera/CameraManager";
 export { CharacterDescription, AnimationConfig } from "./character/Character";
-export { CharacterManager } from "./character/CharacterManager";
+export { CharacterManager, SpawnConfiguration } from "./character/CharacterManager";
 export * from "./character/url-position";
 export * from "./helpers/math-helpers";
 export { CharacterModelLoader } from "./character/CharacterModelLoader";

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -20,6 +20,7 @@ import {
   TimeManager,
   TweakPane,
   SpawnConfiguration,
+  SpawnConfigurationState,
   VirtualJoystick,
 } from "@mml-io/3d-web-client-core";
 import {
@@ -133,7 +134,7 @@ export class Networked3dWebExperienceClient {
   };
   private characterControllerPaneSet: boolean = false;
 
-  private spawnConfiguration: SpawnConfiguration;
+  private spawnConfiguration: SpawnConfigurationState;
 
   private initialLoadCompleted = false;
   private loadingProgressManager = new LoadingProgressManager();
@@ -271,19 +272,19 @@ export class Networked3dWebExperienceClient {
         y: this.config.spawnConfiguration?.spawnPosition?.y ?? 0,
         z: this.config.spawnConfiguration?.spawnPosition?.z ?? 0,
       },
-      spawnPositionvariance: {
-        x: this.config.spawnConfiguration?.spawnPositionvariance?.x ?? 0,
-        y: this.config.spawnConfiguration?.spawnPositionvariance?.y ?? 0,
-        z: this.config.spawnConfiguration?.spawnPositionvariance?.z ?? 0,
+      spawnPositionVariance: {
+        x: this.config.spawnConfiguration?.spawnPositionVariance?.x ?? 0,
+        y: this.config.spawnConfiguration?.spawnPositionVariance?.y ?? 0,
+        z: this.config.spawnConfiguration?.spawnPositionVariance?.z ?? 0,
       },
       spawnYRotation: this.config.spawnConfiguration?.spawnYRotation ?? 0,
       respawnTrigger: {
-        minX: this.config.spawnConfiguration?.respawnTrigger?.minX,
-        maxX: this.config.spawnConfiguration?.respawnTrigger?.maxX,
+        minX: this.config.spawnConfiguration?.respawnTrigger?.minX ?? Number.NEGATIVE_INFINITY,
+        maxX: this.config.spawnConfiguration?.respawnTrigger?.maxX ?? Number.POSITIVE_INFINITY,
         minY: this.config.spawnConfiguration?.respawnTrigger?.minY ?? -100,
-        maxY: this.config.spawnConfiguration?.respawnTrigger?.maxY,
-        minZ: this.config.spawnConfiguration?.respawnTrigger?.minZ,
-        maxZ: this.config.spawnConfiguration?.respawnTrigger?.maxZ,
+        maxY: this.config.spawnConfiguration?.respawnTrigger?.maxY ?? Number.POSITIVE_INFINITY,
+        minZ: this.config.spawnConfiguration?.respawnTrigger?.minZ ?? Number.NEGATIVE_INFINITY,
+        maxZ: this.config.spawnConfiguration?.respawnTrigger?.maxZ ?? Number.POSITIVE_INFINITY,
       },
       enableRespawnButton: this.config.spawnConfiguration?.enableRespawnButton ?? false,
     };
@@ -382,6 +383,39 @@ export class Networked3dWebExperienceClient {
         this.connectToTextChat();
       }
     }
+
+    if (config.spawnConfiguration !== undefined) {
+      this.spawnConfiguration = {
+        spawnPosition: {
+          x: config.spawnConfiguration.spawnPosition?.x ?? 0,
+          y: config.spawnConfiguration.spawnPosition?.y ?? 0,
+          z: config.spawnConfiguration.spawnPosition?.z ?? 0,
+        },
+        spawnPositionVariance: {
+          x: config.spawnConfiguration.spawnPositionVariance?.x ?? 0,
+          y: config.spawnConfiguration.spawnPositionVariance?.y ?? 0,
+          z: config.spawnConfiguration.spawnPositionVariance?.z ?? 0,
+        },
+        spawnYRotation: config.spawnConfiguration.spawnYRotation ?? 0,
+        respawnTrigger: {
+          minX: config.spawnConfiguration.respawnTrigger?.minX ?? Number.NEGATIVE_INFINITY,
+          maxX: config.spawnConfiguration.respawnTrigger?.maxX ?? Number.POSITIVE_INFINITY,
+          minY: config.spawnConfiguration.respawnTrigger?.minY ?? -100,
+          maxY: config.spawnConfiguration.respawnTrigger?.maxY ?? Number.POSITIVE_INFINITY,
+          minZ: config.spawnConfiguration.respawnTrigger?.minZ ?? Number.NEGATIVE_INFINITY,
+          maxZ: config.spawnConfiguration.respawnTrigger?.maxZ ?? Number.POSITIVE_INFINITY,
+        },
+        enableRespawnButton:
+          config.spawnConfiguration.enableRespawnButton !== undefined
+            ? config.spawnConfiguration.enableRespawnButton
+            : false,
+      };
+
+      if (this.characterManager.localController) {
+        this.characterManager.localController.updateSpawnConfig(this.spawnConfiguration);
+      }
+    }
+
     if (config.mmlDocuments) {
       this.setMMLDocuments(config.mmlDocuments);
     }
@@ -589,16 +623,16 @@ export class Networked3dWebExperienceClient {
     const spawnPosition = new Vector3();
     spawnPosition.set(
       this.randomWithVariance(
-        this.spawnConfiguration.spawnPosition!.x,
-        this.spawnConfiguration.spawnPositionvariance!.x,
+        this.spawnConfiguration.spawnPosition.x,
+        this.spawnConfiguration.spawnPositionVariance.x,
       ),
       this.randomWithVariance(
-        this.spawnConfiguration.spawnPosition!.y,
-        this.spawnConfiguration.spawnPositionvariance!.y,
+        this.spawnConfiguration.spawnPosition.y,
+        this.spawnConfiguration.spawnPositionVariance.y,
       ),
       this.randomWithVariance(
         this.spawnConfiguration.spawnPosition!.z,
-        this.spawnConfiguration.spawnPositionvariance!.z,
+        this.spawnConfiguration.spawnPositionVariance.z,
       ),
     );
     const spawnRotation = new Euler(

--- a/packages/3d-web-text-chat/src/chat-ui/components/Input/InputBox.module.css
+++ b/packages/3d-web-text-chat/src/chat-ui/components/Input/InputBox.module.css
@@ -19,7 +19,6 @@
 .sendButton {
   width: 40px;
   height: 38px;
-  border: none;
   border-radius: 25%;
   color: #ffffff;
   background-color: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
Resolves #207 

This PR adds configurable (re)spawn settings that can be passed through the Networked3dWebExperienceClient's options.

config example:
```
spawnConfiguration: {
  spawnPosition: { x: 5, y: 0, z: 5 },
  spawnPositionvariance: { x: 7, y: 0, z: 7 },
  spawnYRotation: 45,
  enableRespawnButton: true,
},
```

- `spawnPosition`: player spawn position (default: 0, 0, 0)
- `spawnPositionVariance`: how many meters from the spawnPosition the spawn may randomly vary (default: 0, 0, 0)
- `spawnRotation`: player spawn rotation, in degrees, clockwise (default: 0)
- `enableRespawnButton`: will add a respawn button if tru (default: false)

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] The title references the corresponding issue # (if relevant)
