### PR TITLE
converts allowOrbitalCamera into an UpdatableConfig

### DIFF
--- a/example/multi-user-3d-web-experience/client/src/index.ts
+++ b/example/multi-user-3d-web-experience/client/src/index.ts
@@ -34,7 +34,7 @@ const app = new Networked3dWebExperienceClient(holder, {
   avatarConfiguration: {
     availableAvatars: [],
   },
-  allowOrbitalCamera: true,
+  allowOrbitalCamera: false,
   loadingScreen: {
     background: "#424242",
     color: "#ffffff",

--- a/packages/3d-web-client-core/src/camera/CameraManager.ts
+++ b/packages/3d-web-client-core/src/camera/CameraManager.ts
@@ -292,6 +292,10 @@ export class CameraManager {
     }
   }
 
+  public isFlyCameraOn(): boolean {
+    return this.isMainCameraActive === false && this.orbitControls.enabled === true;
+  }
+
   public toggleFlyCamera(): void {
     this.isMainCameraActive = !this.isMainCameraActive;
     this.orbitControls.enabled = !this.isMainCameraActive;

--- a/packages/3d-web-client-core/src/input/KeyInputManager.ts
+++ b/packages/3d-web-client-core/src/input/KeyInputManager.ts
@@ -56,7 +56,19 @@ export class KeyInputManager {
   }
 
   public createKeyBinding(key: Key, callback: () => void): void {
+    if (this.bindings.has(key)) {
+      console.warn(`Key binding for ${key} already exists.`);
+      return;
+    }
     this.bindings.set(key, callback);
+  }
+
+  public removeKeyBinding(key: Key): void {
+    if (!this.bindings.has(key)) {
+      console.warn(`Can't remove key binding for ${key} as it does not exist.`);
+      return;
+    }
+    this.bindings.delete(key);
   }
 
   public isMovementKeyPressed(): boolean {

--- a/packages/3d-web-client-core/src/input/KeyInputManager.ts
+++ b/packages/3d-web-client-core/src/input/KeyInputManager.ts
@@ -57,7 +57,6 @@ export class KeyInputManager {
 
   public createKeyBinding(key: Key, callback: () => void): void {
     if (this.bindings.has(key)) {
-      console.warn(`Key binding for ${key} already exists.`);
       return;
     }
     this.bindings.set(key, callback);
@@ -65,7 +64,6 @@ export class KeyInputManager {
 
   public removeKeyBinding(key: Key): void {
     if (!this.bindings.has(key)) {
-      console.warn(`Can't remove key binding for ${key} as it does not exist.`);
       return;
     }
     this.bindings.delete(key);

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -73,7 +73,6 @@ type MMLDocumentConfiguration = {
 export type Networked3dWebExperienceClientConfig = {
   userNetworkAddress: string;
   sessionToken: string;
-  allowOrbitalCamera?: boolean;
   chatVisibleByDefault?: boolean;
   userNameToColorOptions?: StringToHslOptions;
   animationConfig: AnimationConfig;
@@ -90,6 +89,7 @@ export type UpdatableConfig = {
   avatarConfiguration?: AvatarConfiguration;
   allowCustomDisplayName?: boolean;
   enableTweakPane?: boolean;
+  allowOrbitalCamera?: boolean;
 };
 
 export class Networked3dWebExperienceClient {
@@ -342,6 +342,24 @@ export class Networked3dWebExperienceClient {
         this.tweakPane = null;
       } else if (config.enableTweakPane === true && this.tweakPane === null) {
         this.setupTweakPane();
+      }
+    }
+
+    if (config.allowOrbitalCamera !== undefined) {
+      if (config.allowOrbitalCamera === false) {
+        this.keyInputManager.removeKeyBinding(Key.C);
+        if (this.cameraManager.isFlyCameraOn() === true) {
+          // Disable the fly camera if it was enabled
+          this.cameraManager.toggleFlyCamera();
+        }
+      } else if (config.allowOrbitalCamera === true) {
+        this.keyInputManager.createKeyBinding(Key.C, () => {
+          if (document.activeElement === document.body) {
+            // No input is selected - accept the key press
+            this.cameraManager.toggleFlyCamera();
+            this.composer.fitContainer();
+          }
+        });
       }
     }
 


### PR DESCRIPTION
Resolves #218 

This PR transforms the `allowOrbitalCamera` client config option into an `UpdatableConfig` so apps/services consuming the `3d-web-experience` may change the setting live (without the need to refresh the experience page).

**What kind of change does your PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR fulfill the following requirements?**

- [X] The title references the corresponding issue # (if relevant)
