### PR TITLE
Fix m-interaction interactionShowDistance

### DIFF
--- a/packages/3d-web-client-core/src/mml/MMLCompositionScene.ts
+++ b/packages/3d-web-client-core/src/mml/MMLCompositionScene.ts
@@ -57,9 +57,9 @@ export class MMLCompositionScene {
       getRootContainer: () => {
         return this.group;
       },
-      interactionShouldShowDistance(
+      interactionShouldShowDistance: (
         interaction: Interaction<ThreeJSGraphicsAdapter>,
-      ): number | null {
+      ): number | null => {
         return ThreeJSInteractionAdapter.interactionShouldShowDistance(
           interaction,
           this.config.camera,


### PR DESCRIPTION
Fixes the implementation of `m-interaction` which was failing to run the `interactionShouldShowDistance` because of incorrect scoping (accessing `this`).

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix