### PR TITLE
Default Rendering Tweaks

### DIFF
--- a/packages/3d-web-client-core/src/character/CharacterMaterial.ts
+++ b/packages/3d-web-client-core/src/character/CharacterMaterial.ts
@@ -135,14 +135,16 @@ export class CharacterMaterial extends MeshStandardMaterial {
         this.opacity = this.currentAlpha;
       }
     }
-    this.metalness = characterValues.metalness;
-    this.roughness = characterValues.roughness;
-    this.emissive = new Color().setRGB(
-      characterValues.emissive.r,
-      characterValues.emissive.g,
-      characterValues.emissive.b,
-    );
-    this.emissiveIntensity = characterValues.emissiveIntensity;
-    this.envMapIntensity = characterValues.envMapIntensity;
+    if (characterValues.overrideMaterialParams) {
+      this.metalness = characterValues.metalness;
+      this.roughness = characterValues.roughness;
+      this.emissive = new Color().setRGB(
+        characterValues.emissive.r,
+        characterValues.emissive.g,
+        characterValues.emissive.b,
+      );
+      this.emissiveIntensity = characterValues.emissiveIntensity;
+      this.envMapIntensity = characterValues.envMapIntensity;
+    }
   }
 }

--- a/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
+++ b/packages/3d-web-client-core/src/tweakpane/TweakPane.ts
@@ -208,6 +208,7 @@ export class TweakPane {
 
   public setupCharacterController(localController: LocalController) {
     this.characterControls.setupChangeEvent(localController);
+    this.character.setupChangeEvent();
   }
 
   public setupPostProcessingPane(postProcessingManager: PostProcessingManager): void {

--- a/packages/3d-web-client-core/src/tweakpane/blades/characterFolder.ts
+++ b/packages/3d-web-client-core/src/tweakpane/blades/characterFolder.ts
@@ -2,6 +2,7 @@ import { BladeController, View } from "@tweakpane/core";
 import { BladeApi, FolderApi, TpChangeEvent } from "tweakpane";
 
 export const characterValues = {
+  overrideMaterialParams: false,
   metalness: 0.2,
   roughness: 0.8,
   emissive: { r: 1.0, g: 1.0, b: 1.0 },
@@ -18,26 +19,56 @@ const characterOptions = {
 
 export class CharacterFolder {
   private folder: FolderApi;
+  private materialParamsFolder: FolderApi;
+
   constructor(parentFolder: FolderApi, expand: boolean = false) {
     this.folder = parentFolder.addFolder({ title: "characterMaterial", expanded: expand });
-    this.folder.addBinding(characterValues, "metalness", characterOptions.metalness);
-    this.folder.addBinding(characterValues, "roughness", characterOptions.roughness);
-    this.folder.addBinding(characterValues, "emissive", {
+
+    // Add the override toggle
+    this.folder.addBinding(characterValues, "overrideMaterialParams", {
+      label: "override material params",
+    });
+
+    // Create material parameters folder (always create, control visibility with hidden property)
+    this.materialParamsFolder = this.folder.addFolder({
+      title: "Material Parameters",
+      expanded: true,
+    });
+
+    this.materialParamsFolder.addBinding(characterValues, "metalness", characterOptions.metalness);
+    this.materialParamsFolder.addBinding(characterValues, "roughness", characterOptions.roughness);
+    this.materialParamsFolder.addBinding(characterValues, "emissive", {
       color: { type: "float" },
     });
-    this.folder.addBinding(
+    this.materialParamsFolder.addBinding(
       characterValues,
       "emissiveIntensity",
       characterOptions.emissiveIntensity,
     );
-    this.folder.addBinding(characterValues, "envMapIntensity", characterOptions.envMapIntensity);
+    this.materialParamsFolder.addBinding(
+      characterValues,
+      "envMapIntensity",
+      characterOptions.envMapIntensity,
+    );
+
+    // Set initial visibility
+    this.updateMaterialParamsVisibility();
+  }
+
+  private updateMaterialParamsVisibility(): void {
+    this.materialParamsFolder.hidden = !characterValues.overrideMaterialParams;
   }
 
   public setupChangeEvent(): void {
     this.folder.on("change", (e: TpChangeEvent<unknown, BladeApi<BladeController<View>>>) => {
       const target = (e.target as any).key;
       if (!target) return;
+
       switch (target) {
+        case "overrideMaterialParams": {
+          this.updateMaterialParamsVisibility();
+          break;
+        }
         case "emissive": {
           const value = e.value as { r: number; g: number; b: number };
           characterValues.emissive = {

--- a/packages/3d-web-client-core/src/tweakpane/blades/environmentFolder.ts
+++ b/packages/3d-web-client-core/src/tweakpane/blades/environmentFolder.ts
@@ -18,7 +18,7 @@ export const sunValues = {
 const sunOptions = {
   sunPosition: {
     sunAzimuthalAngle: { min: 0, max: 360, step: 1 },
-    sunPolarAngle: { min: -90, max: 90, step: 1 },
+    sunPolarAngle: { min: -95, max: 95, step: 1 },
   },
   sunIntensity: { min: 0, max: 10, step: 0.1 },
   skyTurbidity: { min: 1, max: 30, step: 0.1 },
@@ -30,7 +30,7 @@ const sunOptions = {
 export const envValues = {
   skyboxAzimuthalAngle: 0,
   skyboxPolarAngle: 0,
-  envMapIntensity: 0.21,
+  envMapIntensity: 0.6,
   skyboxIntensity: 0.9,
   skyboxBlurriness: 0.0,
   ambientLight: {

--- a/packages/3d-web-client-core/src/tweakpane/blades/rendererFolder.ts
+++ b/packages/3d-web-client-core/src/tweakpane/blades/rendererFolder.ts
@@ -1,12 +1,12 @@
 import { BladeController, View } from "@tweakpane/core";
 import { EffectPass } from "postprocessing";
-import { ShadowMapType, ToneMapping, WebGLRenderer } from "three";
+import { NoToneMapping, ShadowMapType, ToneMapping, WebGLRenderer } from "three";
 import { BladeApi, FolderApi, TpChangeEvent } from "tweakpane";
 
 export const rendererValues = {
   shadowMap: 2,
-  toneMapping: 5,
-  exposure: 2.1,
+  toneMapping: 4,
+  exposure: 0.75,
 };
 
 const rendererOptions = {
@@ -79,6 +79,7 @@ export class RendererFolder {
           const value = e.value as ToneMapping;
           toneMappingFolder.hidden = e.value !== 5;
           toneMappingPass.enabled = e.value === 5 ? true : false;
+          renderer.toneMapping = e.value === 5 ? NoToneMapping : (e.value as ToneMapping);
           setToneMappingType(e.value as ToneMapping);
           break;
         case "exposure":


### PR DESCRIPTION
- Tune default tonemapping and lighting for atmospheric sky
- Fix tonemapping config in tweak pane to switch between native THREE tonemapping and custom tonemapping approaches
- Disable character material property overriding by default to preserve MML roughness/metal/emissive material properties 