### PR TITLE
feat: character-centric audio listener

### DIFF
--- a/packages/3d-web-client-core/src/character/Character.ts
+++ b/packages/3d-web-client-core/src/character/Character.ts
@@ -1,4 +1,4 @@
-import { AnimationClip, Color, Group, Object3D, Quaternion } from "three";
+import { AnimationClip, Color, Group, Object3D, Quaternion, Vector3 } from "three";
 
 import { CameraManager } from "../camera/CameraManager";
 import { EulXYZ } from "../math/EulXYZ";
@@ -346,6 +346,15 @@ export class Character extends Group {
 
   public getMesh(): Object3D | null {
     return this.model?.mesh || null;
+  }
+
+  public getHeadWorldPosition(): Vector3 | null {
+    if (this.model?.headBone) {
+      const worldPosition = new Vector3();
+      this.model.headBone.getWorldPosition(worldPosition);
+      return worldPosition;
+    }
+    return null;
   }
 
   dispose() {


### PR DESCRIPTION
This PR changes the behaviour of the audio listener to be positioned at the head of the local user's avatar and fallback to the camera position if the character is not loaded.

**What kind of change does your PR introduce?** (check at least one)

- [x] Feature
