### PR TITLE
fix: world-relative rotation from surfaces

### DIFF
--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -509,8 +509,8 @@ export class LocalController {
           .copy(userPosition)
           .sub(lastMeshPosition);
 
-        // Calculate the relative quaternion of the mesh in the last frame to the mesh in the current frame
-        const meshRotationDelta = lastMeshRotation.invert().multiply(currentMeshRotation);
+        // Calculate the world-relative rotation delta from the last frame to the current frame
+        const meshRotationDelta = currentMeshRotation.multiply(lastMeshRotation.invert());
 
         // Apply the relative quaternion to the relative user position to determine the new position of the user given just the rotation
         const translationDueToRotation = this.surfaceTempVector4


### PR DESCRIPTION
This PR fixes an issue with movement of avatars based on surfaces they're standing on. 

Given the example case of a cylinder that is rotated in `z` and then animated around `y`:

```
<m-cylinder height="10" radius="3" x="20" rz="90">
  <m-attr-anim attr="rx" start="0" end="360" duration="2000" loop="true"></m-attr-anim>
</m-cylinder>
```

The avatar would previously rotate in `y` as if the cylinder was "upright" - seeming to ignore the rotation of the cylinder around `z`.

Before:
![before](https://github.com/user-attachments/assets/54fb30b8-f7a0-454d-83e1-7536b429643d)

After:
![after](https://github.com/user-attachments/assets/e5427607-be58-45d3-afcc-1d31588edf6e)

**What kind of change does your PR introduce?** (check at least one)

- [x] Bugfix
