### PR TITLE
fix: use wildcard versions for workspace deps in example packages

### DIFF
--- a/example/bridge-bots/package.json
+++ b/example/bridge-bots/package.json
@@ -7,8 +7,8 @@
     "iterate": "node --import tsx src/index.ts"
   },
   "dependencies": {
-    "@mml-io/3d-web-experience-bridge": "^0.27.1",
-    "@mml-io/3d-web-experience-server": "^0.27.1",
+    "@mml-io/3d-web-experience-bridge": "*",
+    "@mml-io/3d-web-experience-server": "*",
     "express": "4.21.2",
     "tsx": "^4.19.4"
   }

--- a/example/cli/package.json
+++ b/example/cli/package.json
@@ -7,6 +7,6 @@
     "iterate": "node --watch-path=../../packages/3d-web/build --watch-preserve-output ../../packages/3d-web/build/index.js serve world.json --port 8085"
   },
   "dependencies": {
-    "@mml-io/3d-web-experience": "^0.27.1"
+    "@mml-io/3d-web-experience": "*"
   }
 }

--- a/example/local-only-multi-user-3d-web-experience/client/package.json
+++ b/example/local-only-multi-user-3d-web-experience/client/package.json
@@ -15,8 +15,8 @@
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"
   },
   "dependencies": {
-    "@mml-io/3d-web-client-core": "^0.27.1",
-    "@mml-io/3d-web-threejs": "^0.27.1",
+    "@mml-io/3d-web-client-core": "*",
+    "@mml-io/3d-web-threejs": "*",
     "@mml-io/mml-web": "0.26.1",
     "@mml-io/mml-web-runner": "0.26.1",
     "@mml-io/mml-web-threejs-standalone": "0.26.1",

--- a/example/multi-user-3d-web-experience/client/package.json
+++ b/example/multi-user-3d-web-experience/client/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"
   },
   "dependencies": {
-    "@mml-io/3d-web-experience-client": "^0.27.1"
+    "@mml-io/3d-web-experience-client": "*"
   },
   "devDependencies": {
     "esbuild": "0.24.2",

--- a/example/multi-user-3d-web-experience/server/package.json
+++ b/example/multi-user-3d-web-experience/server/package.json
@@ -18,8 +18,8 @@
     "lint-fix": "eslint \"./{src,test}/**/*.{js,jsx,ts,tsx}\" --fix"
   },
   "dependencies": {
-    "@mml-io/3d-web-experience-server": "^0.27.1",
-    "@mml-io/3d-web-user-networking": "^0.27.1",
+    "@mml-io/3d-web-experience-server": "*",
+    "@mml-io/3d-web-user-networking": "*",
     "express": "4.21.2"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,8 @@
       "name": "@example/bridge-bots",
       "version": "0.27.1",
       "dependencies": {
-        "@mml-io/3d-web-experience-bridge": "^0.27.1",
-        "@mml-io/3d-web-experience-server": "^0.27.1",
+        "@mml-io/3d-web-experience-bridge": "*",
+        "@mml-io/3d-web-experience-server": "*",
         "express": "4.21.2",
         "tsx": "^4.19.4"
       }
@@ -561,15 +561,15 @@
       "name": "@example/cli",
       "version": "0.27.1",
       "dependencies": {
-        "@mml-io/3d-web-experience": "^0.27.1"
+        "@mml-io/3d-web-experience": "*"
       }
     },
     "example/local-only-multi-user-3d-web-experience/client": {
       "name": "@example/local-only-multi-user-3d-web-experience-client",
       "version": "0.27.1",
       "dependencies": {
-        "@mml-io/3d-web-client-core": "^0.27.1",
-        "@mml-io/3d-web-threejs": "^0.27.1",
+        "@mml-io/3d-web-client-core": "*",
+        "@mml-io/3d-web-threejs": "*",
         "@mml-io/mml-web": "0.26.1",
         "@mml-io/mml-web-runner": "0.26.1",
         "@mml-io/mml-web-threejs-standalone": "0.26.1",
@@ -647,7 +647,7 @@
       "name": "@example/multi-user-3d-web-experience-client",
       "version": "0.27.1",
       "dependencies": {
-        "@mml-io/3d-web-experience-client": "^0.27.1"
+        "@mml-io/3d-web-experience-client": "*"
       },
       "devDependencies": {
         "esbuild": "0.24.2",
@@ -658,8 +658,8 @@
       "name": "@example/multi-user-3d-web-experience-server",
       "version": "0.27.1",
       "dependencies": {
-        "@mml-io/3d-web-experience-server": "^0.27.1",
-        "@mml-io/3d-web-user-networking": "^0.27.1",
+        "@mml-io/3d-web-experience-server": "*",
+        "@mml-io/3d-web-user-networking": "*",
         "express": "4.21.2"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Use `"*"` for `@mml-io/*` workspace dependencies in private example packages

Lerna 9 runs `npm install --package-lock-only` during publish. With `--no-private`, lerna doesn't update dependency refs in private packages, so npm falls back to the registry. After a version bump, experimental publishes fail because the new version isn't on the registry until the release publish is approved.

Since these are workspace packages, npm always resolves them locally regardless of the version range — the pinned versions were effectively ignored.

## Test plan
- [ ] Experimental publish CI job passes