### PR TITLE
perf: collision queries, fast-path render, allocation cleanups

### DIFF
--- a/packages/3d-web-client-core/src/character/AnimationMixer.ts
+++ b/packages/3d-web-client-core/src/character/AnimationMixer.ts
@@ -141,22 +141,46 @@ export class AnimationMixer {
     this.currentState = state;
     this.targetState = state;
     this.transitionProgress = 1.0;
-    this.weights = this.createZeroWeights();
-    this.weights[state] = 1.0;
-    this.animationTimes = this.createZeroTimes();
+    const w = this.weights;
+    w[AnimationState.idle] = 0;
+    w[AnimationState.walking] = 0;
+    w[AnimationState.running] = 0;
+    w[AnimationState.jumpToAir] = 0;
+    w[AnimationState.air] = 0;
+    w[AnimationState.airToGround] = 0;
+    w[AnimationState.doubleJump] = 0;
+    w[state] = 1.0;
+    const t = this.animationTimes;
+    t[AnimationState.idle] = 0;
+    t[AnimationState.walking] = 0;
+    t[AnimationState.running] = 0;
+    t[AnimationState.jumpToAir] = 0;
+    t[AnimationState.air] = 0;
+    t[AnimationState.airToGround] = 0;
+    t[AnimationState.doubleJump] = 0;
   }
 
   private updateWeights(): void {
-    this.weights = this.createZeroWeights();
+    // Zero in place rather than allocating a new weights object —
+    // `getWeights` hands the same reference to the renderer each frame, so
+    // callers see the up-to-date values without an allocation per call.
+    const w = this.weights;
+    w[AnimationState.idle] = 0;
+    w[AnimationState.walking] = 0;
+    w[AnimationState.running] = 0;
+    w[AnimationState.jumpToAir] = 0;
+    w[AnimationState.air] = 0;
+    w[AnimationState.airToGround] = 0;
+    w[AnimationState.doubleJump] = 0;
 
     if (this.transitionProgress >= 1.0) {
       // Transition complete
-      this.weights[this.targetState] = 1.0;
+      w[this.targetState] = 1.0;
     } else {
       // In transition: blend between current and target
       const t = this.easeInOut(this.transitionProgress);
-      this.weights[this.currentState] = 1.0 - t;
-      this.weights[this.targetState] = t;
+      w[this.currentState] = 1.0 - t;
+      w[this.targetState] = t;
     }
   }
 

--- a/packages/3d-web-client-core/src/character/AnimationMixer.ts
+++ b/packages/3d-web-client-core/src/character/AnimationMixer.ts
@@ -141,46 +141,20 @@ export class AnimationMixer {
     this.currentState = state;
     this.targetState = state;
     this.transitionProgress = 1.0;
-    const w = this.weights;
-    w[AnimationState.idle] = 0;
-    w[AnimationState.walking] = 0;
-    w[AnimationState.running] = 0;
-    w[AnimationState.jumpToAir] = 0;
-    w[AnimationState.air] = 0;
-    w[AnimationState.airToGround] = 0;
-    w[AnimationState.doubleJump] = 0;
-    w[state] = 1.0;
-    const t = this.animationTimes;
-    t[AnimationState.idle] = 0;
-    t[AnimationState.walking] = 0;
-    t[AnimationState.running] = 0;
-    t[AnimationState.jumpToAir] = 0;
-    t[AnimationState.air] = 0;
-    t[AnimationState.airToGround] = 0;
-    t[AnimationState.doubleJump] = 0;
+    this.weights = this.createZeroWeights();
+    this.weights[state] = 1.0;
+    this.animationTimes = this.createZeroTimes();
   }
 
   private updateWeights(): void {
-    // Zero in place rather than allocating a new weights object —
-    // `getWeights` hands the same reference to the renderer each frame, so
-    // callers see the up-to-date values without an allocation per call.
-    const w = this.weights;
-    w[AnimationState.idle] = 0;
-    w[AnimationState.walking] = 0;
-    w[AnimationState.running] = 0;
-    w[AnimationState.jumpToAir] = 0;
-    w[AnimationState.air] = 0;
-    w[AnimationState.airToGround] = 0;
-    w[AnimationState.doubleJump] = 0;
+    this.weights = this.createZeroWeights();
 
     if (this.transitionProgress >= 1.0) {
-      // Transition complete
-      w[this.targetState] = 1.0;
+      this.weights[this.targetState] = 1.0;
     } else {
-      // In transition: blend between current and target
       const t = this.easeInOut(this.transitionProgress);
-      w[this.currentState] = 1.0 - t;
-      w[this.targetState] = t;
+      this.weights[this.currentState] = 1.0 - t;
+      this.weights[this.targetState] = t;
     }
   }
 

--- a/packages/3d-web-client-core/src/character/AnimationMixer.ts
+++ b/packages/3d-web-client-core/src/character/AnimationMixer.ts
@@ -14,6 +14,7 @@ export type AnimationWeights = {
   [AnimationState.air]: number;
   [AnimationState.airToGround]: number;
   [AnimationState.doubleJump]: number;
+  [AnimationState.emote]: number;
 };
 
 /**
@@ -28,6 +29,7 @@ export type AnimationTimes = {
   [AnimationState.air]: number;
   [AnimationState.airToGround]: number;
   [AnimationState.doubleJump]: number;
+  [AnimationState.emote]: number;
 };
 
 /**
@@ -86,6 +88,7 @@ export class AnimationMixer {
       AnimationState.air,
       AnimationState.airToGround,
       AnimationState.doubleJump,
+      AnimationState.emote,
     ]) {
       if (this.weights[state] > 0) {
         this.animationTimes[state] += deltaTime;
@@ -169,6 +172,7 @@ export class AnimationMixer {
       [AnimationState.air]: 0,
       [AnimationState.airToGround]: 0,
       [AnimationState.doubleJump]: 0,
+      [AnimationState.emote]: 0,
     };
   }
 
@@ -181,6 +185,7 @@ export class AnimationMixer {
       [AnimationState.air]: 0,
       [AnimationState.airToGround]: 0,
       [AnimationState.doubleJump]: 0,
+      [AnimationState.emote]: 0,
     };
   }
 

--- a/packages/3d-web-client-core/src/character/AnimationMixer.ts
+++ b/packages/3d-web-client-core/src/character/AnimationMixer.ts
@@ -150,8 +150,10 @@ export class AnimationMixer {
     this.weights = this.createZeroWeights();
 
     if (this.transitionProgress >= 1.0) {
+      // Transition complete
       this.weights[this.targetState] = 1.0;
     } else {
+      // In transition: blend between current and target
       const t = this.easeInOut(this.transitionProgress);
       this.weights[this.currentState] = 1.0 - t;
       this.weights[this.targetState] = t;

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -93,33 +93,7 @@ export type CharacterManagerConfig = {
     colors: Array<[number, number, number]> | null;
   };
   updateURLLocation?: boolean;
-  /**
-   * Optional per-character predicate. When it returns true for a remote
-   * character's connectionId, that character is processed via a "fast path"
-   * inside `update()` that:
-   *  - snaps position/rotation directly from `networkUpdate` (no
-   *    Vec3.lerp / Quat.slerp interpolation),
-   *  - skips Quat → EulXYZ matrix conversion (writes the eulerY directly
-   *    into renderState.rotation.y),
-   *  - snaps the AnimationMixer to the network-supplied state on change
-   *    (no transition FSM),
-   *  - skips `characterResolve` and the username/description/colors
-   *    equality block — fast-path characters do not emit
-   *    `updatedCharacterDescriptions` while in the fast tier.
-   *
-   * Designed for very high remote-character counts (e.g. 1000+ NPC bots)
-   * where most are too far/non-interactive to need the full per-frame
-   * smoothing/animation-blend pipeline. Consumers typically wire this to a
-   * distance-based LOD policy. Returning false (or omitting the option
-   * entirely) preserves the original full-fidelity behaviour.
-   */
-  useFastPath?: (connectionId: number) => boolean;
-  /**
-   * When true, `CharacterManager.update` skips its remote-character loop
-   * (spawn, slow path, fast path) entirely. The local player still runs.
-   * Used by consumers (notably narwhal) that own their own remote-character
-   * pipeline. Default false for backwards compat.
-   */
+  /** Skip the remote-character loop; consumer (e.g. narwhal) owns it. */
   skipRemoteCharacterUpdate?: boolean;
 };
 
@@ -412,11 +386,7 @@ export class CharacterManager {
       }
     }
 
-    // Process remote characters. The optional `useFastPath` config
-    // predicate selects the cheap path per bot — see the type doc on
-    // `CharacterManagerConfig.useFastPath`.
     if (!this.config.skipRemoteCharacterUpdate) {
-      const useFastPath = this.config.useFastPath;
       for (const [id, networkUpdate] of this.config.remoteUserStates) {
         if (id === this.localConnectionId) {
           continue;
@@ -470,50 +440,6 @@ export class CharacterManager {
           };
           this.remoteCharacters.set(id, existingCharacter);
           this.cachedCharacterStates.set(id, renderState);
-        } else if (useFastPath?.(id)) {
-          // Fast path. Snap position and rotation from network state; advance
-          // the animation mixer directly to the network-supplied state on
-          // change; skip characterResolve and the description equality block
-          // (username/colors are read from the spawn-time renderState fields,
-          // which is correct for non-interactive crowd characters).
-          const nu = networkUpdate;
-          const c = existingCharacter;
-
-          // Position: snap (no Vec3.lerp). Keep the controller's mirror in
-          // sync so promotion back to the slow path resumes from the
-          // current visible position, not a stale interpolated one.
-          c.controller.position.set(nu.position.x, nu.position.y, nu.position.z);
-          c.renderState.position.set(nu.position.x, nu.position.y, nu.position.z);
-
-          // Rotation: write the network-supplied yaw directly into the
-          // renderState's EulXYZ. The slow path does Quat → matrix → Eul; the
-          // fast path skips that. Keep the controller's quaternion in sync
-          // for the same promotion-resume reason.
-          c.renderState.rotation.x = 0;
-          c.renderState.rotation.y = nu.rotation.eulerY;
-          c.renderState.rotation.z = 0;
-          const halfY = nu.rotation.eulerY / 2;
-          c.controller.rotation.set(0, Math.sin(halfY), 0, Math.cos(halfY));
-          c.controller.animationState = nu.state;
-
-          // Animation: snap the mixer to the network state on change so its
-          // weights array (returned by reference from getWeights) reflects
-          // a single dominant state with weight 1. Otherwise just advance
-          // animation times (cheap 7-state for-loop) so clips keep playing.
-          if (c.animationMixer.getPrimaryState() !== nu.state) {
-            c.animationMixer.snapToState(nu.state);
-          }
-          c.animationMixer.update(deltaTime);
-
-          c.renderState.animationState = nu.state;
-          c.renderState.animationWeights = c.animationMixer.getWeights();
-          c.renderState.animationTimes = c.animationMixer.getAnimationTimes();
-
-          // Skip characterResolve / equality / updatedCharacterDescriptions —
-          // the spawn-time username/description/colors remain in renderState.
-          // If a consumer needs to refresh those for a fast-path character it
-          // can do so out-of-band; the typical use case (crowd bots whose
-          // identity never changes) does not need this.
         } else {
           // Update existing character's controller with network state
           existingCharacter.controller.update(networkUpdate, deltaTime);
@@ -584,12 +510,7 @@ export class CharacterManager {
     return this.localConnectionId;
   }
 
-  /**
-   * Returns the live network-truth map of remote-user states. Consumers
-   * (notably narwhal's renderer wrapper) that own the remote-character
-   * pipeline can read this directly to sidestep CharacterManager's
-   * per-frame processing — pair with `skipRemoteCharacterUpdate: true`.
-   */
+  /** Live network-truth map; pair with `skipRemoteCharacterUpdate: true`. */
   public getRemoteUserStates(): ReadonlyMap<number, CharacterState> {
     return this.config.remoteUserStates;
   }

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -93,6 +93,27 @@ export type CharacterManagerConfig = {
     colors: Array<[number, number, number]> | null;
   };
   updateURLLocation?: boolean;
+  /**
+   * Optional per-character predicate. When it returns true for a remote
+   * character's connectionId, that character is processed via a "fast path"
+   * inside `update()` that:
+   *  - snaps position/rotation directly from `networkUpdate` (no
+   *    Vec3.lerp / Quat.slerp interpolation),
+   *  - skips Quat → EulXYZ matrix conversion (writes the eulerY directly
+   *    into renderState.rotation.y),
+   *  - snaps the AnimationMixer to the network-supplied state on change
+   *    (no transition FSM),
+   *  - skips `characterResolve` and the username/description/colors
+   *    equality block — fast-path characters do not emit
+   *    `updatedCharacterDescriptions` while in the fast tier.
+   *
+   * Designed for very high remote-character counts (e.g. 1000+ NPC bots)
+   * where most are too far/non-interactive to need the full per-frame
+   * smoothing/animation-blend pipeline. Consumers typically wire this to a
+   * distance-based LOD policy. Returning false (or omitting the option
+   * entirely) preserves the original full-fidelity behaviour.
+   */
+  useFastPath?: (connectionId: number) => boolean;
 };
 
 type RemoteCharacterState = {
@@ -384,7 +405,13 @@ export class CharacterManager {
       }
     }
 
-    // Process remote characters
+    // Process remote characters. The optional `useFastPath` config
+    // predicate (or the runtime-only ablation flag
+    // `globalThis.__ABL_FAST_PATH_FORCE_ALL__`) selects the cheap path per
+    // bot — see the type doc on `CharacterManagerConfig.useFastPath`.
+    const useFastPath = this.config.useFastPath;
+    const _ablForceAll = !!(globalThis as { __ABL_FAST_PATH_FORCE_ALL__?: boolean })
+      .__ABL_FAST_PATH_FORCE_ALL__;
     for (const [id, networkUpdate] of this.config.remoteUserStates) {
       if (id === this.localConnectionId) {
         continue;
@@ -434,6 +461,50 @@ export class CharacterManager {
         };
         this.remoteCharacters.set(id, existingCharacter);
         this.cachedCharacterStates.set(id, renderState);
+      } else if (_ablForceAll || useFastPath?.(id)) {
+        // Fast path. Snap position and rotation from network state; advance
+        // the animation mixer directly to the network-supplied state on
+        // change; skip characterResolve and the description equality block
+        // (username/colors are read from the spawn-time renderState fields,
+        // which is correct for non-interactive crowd characters).
+        const nu = networkUpdate;
+        const c = existingCharacter;
+
+        // Position: snap (no Vec3.lerp). Keep the controller's mirror in
+        // sync so promotion back to the slow path resumes from the
+        // current visible position, not a stale interpolated one.
+        c.controller.position.set(nu.position.x, nu.position.y, nu.position.z);
+        c.renderState.position.set(nu.position.x, nu.position.y, nu.position.z);
+
+        // Rotation: write the network-supplied yaw directly into the
+        // renderState's EulXYZ. The slow path does Quat → matrix → Eul; the
+        // fast path skips that. Keep the controller's quaternion in sync
+        // for the same promotion-resume reason.
+        c.renderState.rotation.x = 0;
+        c.renderState.rotation.y = nu.rotation.eulerY;
+        c.renderState.rotation.z = 0;
+        const halfY = nu.rotation.eulerY / 2;
+        c.controller.rotation.set(0, Math.sin(halfY), 0, Math.cos(halfY));
+        c.controller.animationState = nu.state;
+
+        // Animation: snap the mixer to the network state on change so its
+        // weights array (returned by reference from getWeights) reflects
+        // a single dominant state with weight 1. Otherwise just advance
+        // animation times (cheap 7-state for-loop) so clips keep playing.
+        if (c.animationMixer.getPrimaryState() !== nu.state) {
+          c.animationMixer.snapToState(nu.state);
+        }
+        c.animationMixer.update(deltaTime);
+
+        c.renderState.animationState = nu.state;
+        c.renderState.animationWeights = c.animationMixer.getWeights();
+        c.renderState.animationTimes = c.animationMixer.getAnimationTimes();
+
+        // Skip characterResolve / equality / updatedCharacterDescriptions —
+        // the spawn-time username/description/colors remain in renderState.
+        // If a consumer needs to refresh those for a fast-path character it
+        // can do so out-of-band; the typical use case (crowd bots whose
+        // identity never changes) does not need this.
       } else {
         // Update existing character's controller with network state
         existingCharacter.controller.update(networkUpdate, deltaTime);

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -583,4 +583,14 @@ export class CharacterManager {
   public getLocalConnectionId(): number {
     return this.localConnectionId;
   }
+
+  /**
+   * Returns the live network-truth map of remote-user states. Consumers
+   * (notably narwhal's renderer wrapper) that own the remote-character
+   * pipeline can read this directly to sidestep CharacterManager's
+   * per-frame processing — pair with `skipRemoteCharacterUpdate: true`.
+   */
+  public getRemoteUserStates(): ReadonlyMap<number, CharacterState> {
+    return this.config.remoteUserStates;
+  }
 }

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -93,7 +93,7 @@ export type CharacterManagerConfig = {
     colors: Array<[number, number, number]> | null;
   };
   updateURLLocation?: boolean;
-  /** Skip the remote-character loop; consumer (e.g. narwhal) owns it. */
+  /** Skip the remote-character loop; the renderer owns it. */
   skipRemoteCharacterUpdate?: boolean;
 };
 

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -114,6 +114,13 @@ export type CharacterManagerConfig = {
    * entirely) preserves the original full-fidelity behaviour.
    */
   useFastPath?: (connectionId: number) => boolean;
+  /**
+   * When true, `CharacterManager.update` skips its remote-character loop
+   * (spawn, slow path, fast path) entirely. The local player still runs.
+   * Used by consumers (notably narwhal) that own their own remote-character
+   * pipeline. Default false for backwards compat.
+   */
+  skipRemoteCharacterUpdate?: boolean;
 };
 
 type RemoteCharacterState = {
@@ -409,143 +416,149 @@ export class CharacterManager {
     // predicate (or the runtime-only ablation flag
     // `globalThis.__ABL_FAST_PATH_FORCE_ALL__`) selects the cheap path per
     // bot — see the type doc on `CharacterManagerConfig.useFastPath`.
-    const useFastPath = this.config.useFastPath;
-    const _ablForceAll = !!(globalThis as { __ABL_FAST_PATH_FORCE_ALL__?: boolean })
-      .__ABL_FAST_PATH_FORCE_ALL__;
-    for (const [id, networkUpdate] of this.config.remoteUserStates) {
-      if (id === this.localConnectionId) {
-        continue;
-      }
-
-      let existingCharacter = this.remoteCharacters.get(id);
-      if (!existingCharacter) {
-        // Spawn new remote character with a RemoteController
-        const { position } = networkUpdate;
-        const halfY = networkUpdate.rotation.eulerY / 2;
-        const initialRotation = new EulXYZ().setFromQuaternion(
-          new Quat(0, Math.sin(halfY), 0, Math.cos(halfY)),
-        );
-
-        const characterInfo = this.config.characterResolve(id);
-        const controller = new RemoteController(
-          new Vect3(position.x, position.y, position.z),
-          initialRotation,
-          networkUpdate.state,
-        );
-        const animationMixer = new AnimationMixer(networkUpdate.state);
-
-        // Initialize cached renderState
-        const cachedRotation = new EulXYZ();
-        cachedRotation.setFromQuaternion(controller.rotation);
-        const renderState: CharacterRenderState = {
-          id,
-          position: new Vect3(controller.position.x, controller.position.y, controller.position.z),
-          rotation: cachedRotation,
-          animationState: controller.animationState,
-          animationWeights: animationMixer.getWeights(),
-          animationTimes: animationMixer.getAnimationTimes(),
-          username: characterInfo.username ?? `Unknown User ${id}`,
-          characterDescription: characterInfo.characterDescription,
-          colors: characterInfo.colors,
-          isLocal: false,
-        };
-
-        existingCharacter = {
-          id,
-          controller,
-          animationMixer,
-          lastUsername: renderState.username,
-          lastCharacterDescription: renderState.characterDescription,
-          lastColors: renderState.colors,
-          renderState,
-        };
-        this.remoteCharacters.set(id, existingCharacter);
-        this.cachedCharacterStates.set(id, renderState);
-      } else if (_ablForceAll || useFastPath?.(id)) {
-        // Fast path. Snap position and rotation from network state; advance
-        // the animation mixer directly to the network-supplied state on
-        // change; skip characterResolve and the description equality block
-        // (username/colors are read from the spawn-time renderState fields,
-        // which is correct for non-interactive crowd characters).
-        const nu = networkUpdate;
-        const c = existingCharacter;
-
-        // Position: snap (no Vec3.lerp). Keep the controller's mirror in
-        // sync so promotion back to the slow path resumes from the
-        // current visible position, not a stale interpolated one.
-        c.controller.position.set(nu.position.x, nu.position.y, nu.position.z);
-        c.renderState.position.set(nu.position.x, nu.position.y, nu.position.z);
-
-        // Rotation: write the network-supplied yaw directly into the
-        // renderState's EulXYZ. The slow path does Quat → matrix → Eul; the
-        // fast path skips that. Keep the controller's quaternion in sync
-        // for the same promotion-resume reason.
-        c.renderState.rotation.x = 0;
-        c.renderState.rotation.y = nu.rotation.eulerY;
-        c.renderState.rotation.z = 0;
-        const halfY = nu.rotation.eulerY / 2;
-        c.controller.rotation.set(0, Math.sin(halfY), 0, Math.cos(halfY));
-        c.controller.animationState = nu.state;
-
-        // Animation: snap the mixer to the network state on change so its
-        // weights array (returned by reference from getWeights) reflects
-        // a single dominant state with weight 1. Otherwise just advance
-        // animation times (cheap 7-state for-loop) so clips keep playing.
-        if (c.animationMixer.getPrimaryState() !== nu.state) {
-          c.animationMixer.snapToState(nu.state);
+    if (!this.config.skipRemoteCharacterUpdate) {
+      const useFastPath = this.config.useFastPath;
+      const _ablForceAll = !!(globalThis as { __ABL_FAST_PATH_FORCE_ALL__?: boolean })
+        .__ABL_FAST_PATH_FORCE_ALL__;
+      for (const [id, networkUpdate] of this.config.remoteUserStates) {
+        if (id === this.localConnectionId) {
+          continue;
         }
-        c.animationMixer.update(deltaTime);
 
-        c.renderState.animationState = nu.state;
-        c.renderState.animationWeights = c.animationMixer.getWeights();
-        c.renderState.animationTimes = c.animationMixer.getAnimationTimes();
+        let existingCharacter = this.remoteCharacters.get(id);
+        if (!existingCharacter) {
+          // Spawn new remote character with a RemoteController
+          const { position } = networkUpdate;
+          const halfY = networkUpdate.rotation.eulerY / 2;
+          const initialRotation = new EulXYZ().setFromQuaternion(
+            new Quat(0, Math.sin(halfY), 0, Math.cos(halfY)),
+          );
 
-        // Skip characterResolve / equality / updatedCharacterDescriptions —
-        // the spawn-time username/description/colors remain in renderState.
-        // If a consumer needs to refresh those for a fast-path character it
-        // can do so out-of-band; the typical use case (crowd bots whose
-        // identity never changes) does not need this.
-      } else {
-        // Update existing character's controller with network state
-        existingCharacter.controller.update(networkUpdate, deltaTime);
+          const characterInfo = this.config.characterResolve(id);
+          const controller = new RemoteController(
+            new Vect3(position.x, position.y, position.z),
+            initialRotation,
+            networkUpdate.state,
+          );
+          const animationMixer = new AnimationMixer(networkUpdate.state);
 
-        // Update animation mixer
-        existingCharacter.animationMixer.setTargetState(
-          existingCharacter.controller.animationState,
-        );
-        existingCharacter.animationMixer.update(deltaTime);
+          // Initialize cached renderState
+          const cachedRotation = new EulXYZ();
+          cachedRotation.setFromQuaternion(controller.rotation);
+          const renderState: CharacterRenderState = {
+            id,
+            position: new Vect3(
+              controller.position.x,
+              controller.position.y,
+              controller.position.z,
+            ),
+            rotation: cachedRotation,
+            animationState: controller.animationState,
+            animationWeights: animationMixer.getWeights(),
+            animationTimes: animationMixer.getAnimationTimes(),
+            username: characterInfo.username ?? `Unknown User ${id}`,
+            characterDescription: characterInfo.characterDescription,
+            colors: characterInfo.colors,
+            isLocal: false,
+          };
 
-        // Mutate cached renderState in-place
-        existingCharacter.renderState.position.set(
-          existingCharacter.controller.position.x,
-          existingCharacter.controller.position.y,
-          existingCharacter.controller.position.z,
-        );
-        existingCharacter.renderState.rotation.setFromQuaternion(
-          existingCharacter.controller.rotation,
-        );
-        existingCharacter.renderState.animationState =
-          existingCharacter.animationMixer.getPrimaryState();
-        existingCharacter.renderState.animationWeights =
-          existingCharacter.animationMixer.getWeights();
-        existingCharacter.renderState.animationTimes =
-          existingCharacter.animationMixer.getAnimationTimes();
+          existingCharacter = {
+            id,
+            controller,
+            animationMixer,
+            lastUsername: renderState.username,
+            lastCharacterDescription: renderState.characterDescription,
+            lastColors: renderState.colors,
+            renderState,
+          };
+          this.remoteCharacters.set(id, existingCharacter);
+          this.cachedCharacterStates.set(id, renderState);
+        } else if (_ablForceAll || useFastPath?.(id)) {
+          // Fast path. Snap position and rotation from network state; advance
+          // the animation mixer directly to the network-supplied state on
+          // change; skip characterResolve and the description equality block
+          // (username/colors are read from the spawn-time renderState fields,
+          // which is correct for non-interactive crowd characters).
+          const nu = networkUpdate;
+          const c = existingCharacter;
 
-        // Check if description changed
-        const characterInfo = this.config.characterResolve(id);
-        const newUsername = characterInfo.username ?? `Unknown User ${id}`;
-        if (
-          existingCharacter.lastUsername !== newUsername ||
-          existingCharacter.lastCharacterDescription !== characterInfo.characterDescription ||
-          existingCharacter.lastColors !== characterInfo.colors
-        ) {
-          existingCharacter.lastUsername = newUsername;
-          existingCharacter.lastCharacterDescription = characterInfo.characterDescription;
-          existingCharacter.lastColors = characterInfo.colors;
-          existingCharacter.renderState.username = newUsername;
-          existingCharacter.renderState.characterDescription = characterInfo.characterDescription;
-          existingCharacter.renderState.colors = characterInfo.colors;
-          updatedCharacterDescriptions.push(id);
+          // Position: snap (no Vec3.lerp). Keep the controller's mirror in
+          // sync so promotion back to the slow path resumes from the
+          // current visible position, not a stale interpolated one.
+          c.controller.position.set(nu.position.x, nu.position.y, nu.position.z);
+          c.renderState.position.set(nu.position.x, nu.position.y, nu.position.z);
+
+          // Rotation: write the network-supplied yaw directly into the
+          // renderState's EulXYZ. The slow path does Quat → matrix → Eul; the
+          // fast path skips that. Keep the controller's quaternion in sync
+          // for the same promotion-resume reason.
+          c.renderState.rotation.x = 0;
+          c.renderState.rotation.y = nu.rotation.eulerY;
+          c.renderState.rotation.z = 0;
+          const halfY = nu.rotation.eulerY / 2;
+          c.controller.rotation.set(0, Math.sin(halfY), 0, Math.cos(halfY));
+          c.controller.animationState = nu.state;
+
+          // Animation: snap the mixer to the network state on change so its
+          // weights array (returned by reference from getWeights) reflects
+          // a single dominant state with weight 1. Otherwise just advance
+          // animation times (cheap 7-state for-loop) so clips keep playing.
+          if (c.animationMixer.getPrimaryState() !== nu.state) {
+            c.animationMixer.snapToState(nu.state);
+          }
+          c.animationMixer.update(deltaTime);
+
+          c.renderState.animationState = nu.state;
+          c.renderState.animationWeights = c.animationMixer.getWeights();
+          c.renderState.animationTimes = c.animationMixer.getAnimationTimes();
+
+          // Skip characterResolve / equality / updatedCharacterDescriptions —
+          // the spawn-time username/description/colors remain in renderState.
+          // If a consumer needs to refresh those for a fast-path character it
+          // can do so out-of-band; the typical use case (crowd bots whose
+          // identity never changes) does not need this.
+        } else {
+          // Update existing character's controller with network state
+          existingCharacter.controller.update(networkUpdate, deltaTime);
+
+          // Update animation mixer
+          existingCharacter.animationMixer.setTargetState(
+            existingCharacter.controller.animationState,
+          );
+          existingCharacter.animationMixer.update(deltaTime);
+
+          // Mutate cached renderState in-place
+          existingCharacter.renderState.position.set(
+            existingCharacter.controller.position.x,
+            existingCharacter.controller.position.y,
+            existingCharacter.controller.position.z,
+          );
+          existingCharacter.renderState.rotation.setFromQuaternion(
+            existingCharacter.controller.rotation,
+          );
+          existingCharacter.renderState.animationState =
+            existingCharacter.animationMixer.getPrimaryState();
+          existingCharacter.renderState.animationWeights =
+            existingCharacter.animationMixer.getWeights();
+          existingCharacter.renderState.animationTimes =
+            existingCharacter.animationMixer.getAnimationTimes();
+
+          // Check if description changed
+          const characterInfo = this.config.characterResolve(id);
+          const newUsername = characterInfo.username ?? `Unknown User ${id}`;
+          if (
+            existingCharacter.lastUsername !== newUsername ||
+            existingCharacter.lastCharacterDescription !== characterInfo.characterDescription ||
+            existingCharacter.lastColors !== characterInfo.colors
+          ) {
+            existingCharacter.lastUsername = newUsername;
+            existingCharacter.lastCharacterDescription = characterInfo.characterDescription;
+            existingCharacter.lastColors = characterInfo.colors;
+            existingCharacter.renderState.username = newUsername;
+            existingCharacter.renderState.characterDescription = characterInfo.characterDescription;
+            existingCharacter.renderState.colors = characterInfo.colors;
+            updatedCharacterDescriptions.push(id);
+          }
         }
       }
     }

--- a/packages/3d-web-client-core/src/character/CharacterManager.ts
+++ b/packages/3d-web-client-core/src/character/CharacterManager.ts
@@ -413,13 +413,10 @@ export class CharacterManager {
     }
 
     // Process remote characters. The optional `useFastPath` config
-    // predicate (or the runtime-only ablation flag
-    // `globalThis.__ABL_FAST_PATH_FORCE_ALL__`) selects the cheap path per
-    // bot — see the type doc on `CharacterManagerConfig.useFastPath`.
+    // predicate selects the cheap path per bot — see the type doc on
+    // `CharacterManagerConfig.useFastPath`.
     if (!this.config.skipRemoteCharacterUpdate) {
       const useFastPath = this.config.useFastPath;
-      const _ablForceAll = !!(globalThis as { __ABL_FAST_PATH_FORCE_ALL__?: boolean })
-        .__ABL_FAST_PATH_FORCE_ALL__;
       for (const [id, networkUpdate] of this.config.remoteUserStates) {
         if (id === this.localConnectionId) {
           continue;
@@ -473,7 +470,7 @@ export class CharacterManager {
           };
           this.remoteCharacters.set(id, existingCharacter);
           this.cachedCharacterStates.set(id, renderState);
-        } else if (_ablForceAll || useFastPath?.(id)) {
+        } else if (useFastPath?.(id)) {
           // Fast path. Snap position and rotation from network state; advance
           // the animation mixer directly to the network-supplied state on
           // change; skip characterResolve and the description equality block

--- a/packages/3d-web-client-core/src/character/CharacterState.ts
+++ b/packages/3d-web-client-core/src/character/CharacterState.ts
@@ -6,11 +6,7 @@ export enum AnimationState {
   "air" = 4,
   "airToGround" = 5,
   "doubleJump" = 6,
-  // Emote / non-locomotion clip slot. Producers other than LocalController
-  // (e.g. bots in the showcase) emit this to play an emote animation
-  // (clap, wave, etc.) without colliding with locomotion states. Local
-  // input never produces emote — LocalController only returns
-  // idle/walking/running/jumpToAir/air/airToGround/doubleJump.
+  // Non-locomotion clip slot; LocalController never produces this.
   "emote" = 7,
 }
 

--- a/packages/3d-web-client-core/src/character/CharacterState.ts
+++ b/packages/3d-web-client-core/src/character/CharacterState.ts
@@ -6,6 +6,12 @@ export enum AnimationState {
   "air" = 4,
   "airToGround" = 5,
   "doubleJump" = 6,
+  // Emote / non-locomotion clip slot. Producers other than LocalController
+  // (e.g. bots in the showcase) emit this to play an emote animation
+  // (clap, wave, etc.) without colliding with locomotion states. Local
+  // input never produces emote — LocalController only returns
+  // idle/walking/running/jumpToAir/air/airToGround/doubleJump.
+  "emote" = 7,
 }
 
 export type CharacterState = {

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -225,7 +225,6 @@ export class LocalController {
       this.updateRotation(deltaTime);
     }
 
-    this.config.collisionsManager.setCharacterPosition(this.config.position);
     this.config.collisionsManager.setExemptFromCulling(
       this.lastFrameSurfaceState ? this.lastFrameSurfaceState[0] : null,
     );

--- a/packages/3d-web-client-core/src/character/types.ts
+++ b/packages/3d-web-client-core/src/character/types.ts
@@ -4,4 +4,8 @@ export type AnimationConfig = {
   sprintAnimationFileUrl: string;
   airAnimationFileUrl: string;
   doubleJumpAnimationFileUrl: string;
+  // Optional emote/non-locomotion clip. Bound to AnimationState.emote.
+  // When omitted, characters that target emote will crossfade to an
+  // empty mix slot (no clip plays). Local input never targets emote.
+  emoteAnimationFileUrl?: string;
 };

--- a/packages/3d-web-client-core/src/character/types.ts
+++ b/packages/3d-web-client-core/src/character/types.ts
@@ -4,8 +4,5 @@ export type AnimationConfig = {
   sprintAnimationFileUrl: string;
   airAnimationFileUrl: string;
   doubleJumpAnimationFileUrl: string;
-  // Optional emote/non-locomotion clip. Bound to AnimationState.emote.
-  // When omitted, characters that target emote will crossfade to an
-  // empty mix slot (no clip plays). Local input never targets emote.
   emoteAnimationFileUrl?: string;
 };

--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -489,12 +489,10 @@ export class CollisionsManager {
         position: { x: number; y: number; z: number };
       }
     >();
-    // Capsule's world-space AABB. Computed once and re-used as a tight
-    // per-group cull below — the per-group setup inside `applyCollider`
-    // (matrix invert + box transform) is expensive enough that scanning
-    // all groups linearly costs ~30 ms per 1000 groups before any actual
-    // collision work. A cheap AABB-vs-AABB rejection skips the setup for
-    // groups that can't possibly intersect the capsule.
+    // Capsule's world-space AABB. Used as a tight per-group cull — the
+    // per-group setup inside `applyCollider` (matrix invert + box transform)
+    // dominates scan time at high group counts, so an AABB-vs-AABB
+    // rejection skips the setup for groups that can't possibly intersect.
     const sx = tempSegment.start.x;
     const sy = tempSegment.start.y;
     const sz = tempSegment.start.z;

--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -77,10 +77,6 @@ export class CollisionsManager {
   public onDebugChange?: (enabled: boolean) => void;
 
   private cullingEnabled: boolean = true;
-  // Retained because external callers (LocalController, AvatarController)
-  // still write to it via setCharacterPosition, but it is no longer read —
-  // culling is now ray/capsule-vs-AABB, not distance-from-character.
-  private characterPosition: Vect3 = new Vect3();
 
   private exemptFromCulling: CollisionMeshState | null = null;
 
@@ -102,10 +98,6 @@ export class CollisionsManager {
 
   public setCullingEnabled(enabled: boolean): void {
     this.cullingEnabled = enabled;
-  }
-
-  public setCharacterPosition(position: IVect3): void {
-    this.characterPosition.set(position.x, position.y, position.z);
   }
 
   public setExemptFromCulling(meshState: CollisionMeshState | null): void {

--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -77,7 +77,9 @@ export class CollisionsManager {
   public onDebugChange?: (enabled: boolean) => void;
 
   private cullingEnabled: boolean = true;
-  private cullingRadius: number = 50; // max distance from character to consider meshes
+  // Retained because external callers (LocalController, AvatarController)
+  // still write to it via setCharacterPosition, but it is no longer read —
+  // culling is now ray/capsule-vs-AABB, not distance-from-character.
   private characterPosition: Vect3 = new Vect3();
 
   private exemptFromCulling: CollisionMeshState | null = null;

--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -187,6 +187,80 @@ export class CollisionsManager {
     return [minimumDistance, minimumNormal, minimumHit, minimumPoint];
   }
 
+  /**
+   * Raycast against every registered group, returning all hits sorted by
+   * distance (nearest first). One hit per group — `meshBVH.raycastFirst`
+   * gives the closest triangle within each group's BVH.
+   *
+   * Uses the same per-group world-AABB cull as `raycastFirst`, so callers
+   * can rely on this scaling with hit-eligible groups rather than total
+   * group count. Allocates per call (one result object per hit) — meant
+   * for input-rate paths like click resolution, not per-frame physics.
+   */
+  public raycastAll(
+    ray: Ray,
+    maximumDistance: number | null = null,
+  ): Array<{ distance: number; point: Vect3; normal: Vect3; meshState: CollisionMeshState }> {
+    const results: Array<{
+      distance: number;
+      point: Vect3;
+      normal: Vect3;
+      meshState: CollisionMeshState;
+    }> = [];
+    const ox = ray.origin.x;
+    const oy = ray.origin.y;
+    const oz = ray.origin.z;
+    const invDx = 1 / ray.direction.x;
+    const invDy = 1 / ray.direction.y;
+    const invDz = 1 / ray.direction.z;
+    const cullEnabled = this.cullingEnabled;
+    for (const [, collisionMeshState] of this.collisionMeshState) {
+      if (cullEnabled && this.exemptFromCulling !== collisionMeshState) {
+        const tx1 = (collisionMeshState.worldMinX - ox) * invDx;
+        const tx2 = (collisionMeshState.worldMaxX - ox) * invDx;
+        let tmin = tx1 < tx2 ? tx1 : tx2;
+        let tmax = tx1 > tx2 ? tx1 : tx2;
+        const ty1 = (collisionMeshState.worldMinY - oy) * invDy;
+        const ty2 = (collisionMeshState.worldMaxY - oy) * invDy;
+        const tyMin = ty1 < ty2 ? ty1 : ty2;
+        const tyMax = ty1 > ty2 ? ty1 : ty2;
+        if (tyMin > tmin) tmin = tyMin;
+        if (tyMax < tmax) tmax = tyMax;
+        const tz1 = (collisionMeshState.worldMinZ - oz) * invDz;
+        const tz2 = (collisionMeshState.worldMaxZ - oz) * invDz;
+        const tzMin = tz1 < tz2 ? tz1 : tz2;
+        const tzMax = tz1 > tz2 ? tz1 : tz2;
+        if (tzMin > tmin) tmin = tzMin;
+        if (tzMax < tmax) tmax = tzMax;
+        if (tmax < 0 || tmin > tmax) continue;
+        if (maximumDistance !== null && tmin > maximumDistance) continue;
+      }
+      const invertedMatrix = this.tempMatrix.copy(collisionMeshState.matrix).invert();
+      const originalRay = this.tempRay.copy(ray);
+      originalRay.applyMatrix4(invertedMatrix);
+      const hit = collisionMeshState.meshBVH.raycastFirst(originalRay as unknown as ThreeRay, 2);
+      if (!hit) continue;
+      this.tempSegment.start.copy(originalRay.origin);
+      this.tempSegment.end.copy(hit.point);
+      this.tempSegment.applyMatrix4(collisionMeshState.matrix);
+      const dist = this.tempSegment.distance();
+      if (maximumDistance !== null && dist > maximumDistance) continue;
+      const normal = new Vect3();
+      if (hit.normal) {
+        normal.copy(hit.normal);
+      } else {
+        normal.set(0, 1, 0);
+      }
+      normal.applyQuat(this.tempQuat.setFromRotationMatrix(collisionMeshState.matrix)).normalize();
+      const point = new Vect3()
+        .copy(hit.point as unknown as IVect3)
+        .applyMatrix4(collisionMeshState.matrix);
+      results.push({ distance: dist, point, normal, meshState: collisionMeshState });
+    }
+    results.sort((a, b) => a.distance - b.distance);
+    return results;
+  }
+
   public addMeshesGroup(
     group: CollisionSourceRef,
     creationResult: CollisionMesh,

--- a/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
+++ b/packages/3d-web-client-core/src/collisions/CollisionsManager.ts
@@ -21,6 +21,27 @@ export type CollisionMeshState = {
   meshBVH: MeshBVH;
   trackCollisions: boolean;
   boundingSphereRadius: number; // Cached bounding sphere radius for culling
+  // Local-space (mesh-relative) AABB from the meshBVH's root bounds. Stored
+  // so we can recompute the world-space AABB on a matrix change without
+  // re-querying the BVH.
+  localMinX: number;
+  localMinY: number;
+  localMinZ: number;
+  localMaxX: number;
+  localMaxY: number;
+  localMaxZ: number;
+  // World-space AABB, refreshed on every matrix change. Used as a tight
+  // per-frame pre-cull in `applyColliders` (capsule-vs-AABB) and
+  // `raycastFirst` (ray-vs-AABB) — strictly tighter than the legacy
+  // character-radius sphere cull, and critical at high group counts where
+  // the per-group setup before `meshBVH.shapecast` dominates main-thread
+  // physics time.
+  worldMinX: number;
+  worldMinY: number;
+  worldMinZ: number;
+  worldMaxX: number;
+  worldMaxY: number;
+  worldMaxZ: number;
 };
 
 export type CollisionMesh = {
@@ -89,39 +110,6 @@ export class CollisionsManager {
     this.exemptFromCulling = meshState;
   }
 
-  private isMeshWithinCullingDistance(meshState: CollisionMeshState): boolean {
-    if (!this.cullingEnabled) return true;
-
-    // never cull the mesh the player is standing on
-    if (this.exemptFromCulling !== null && meshState === this.exemptFromCulling) {
-      return true;
-    }
-
-    const matrixData = meshState.matrix.data;
-    const dx = matrixData[12] - this.characterPosition.x;
-    const dy = matrixData[13] - this.characterPosition.y;
-    const dz = matrixData[14] - this.characterPosition.z;
-    const distanceSquared = dx * dx + dy * dy + dz * dz;
-
-    // Derive world scale from the matrix rather than localScale, because localScale
-    // only reflects the group's own scale and misses any parent transforms (e.g. an
-    // m-model nested under a scaled parent will have localScale=(1,1,1) while the
-    // matrix correctly includes the parent's scale).
-    const m = matrixData;
-    const sxSq = m[0] * m[0] + m[1] * m[1] + m[2] * m[2];
-    const sySq = m[4] * m[4] + m[5] * m[5] + m[6] * m[6];
-    const szSq = m[8] * m[8] + m[9] * m[9] + m[10] * m[10];
-    const maxScaleSq = Math.max(sxSq, sySq, szSq);
-
-    // Check: distSq <= (R + bsr * maxScale)^2, rearranged to avoid sqrt entirely.
-    // Let L = distSq - R² - bsr²·maxScaleSq. If L <= 0, within range. Otherwise
-    // square both sides of L <= 2·R·bsr·maxScale to get L² <= 4·R²·bsr²·maxScaleSq.
-    const R = this.cullingRadius;
-    const bsr = meshState.boundingSphereRadius;
-    const L = distanceSquared - R * R - bsr * bsr * maxScaleSq;
-    return L <= 0 || L * L <= 4 * R * R * bsr * bsr * maxScaleSq;
-  }
-
   public raycastFirst(
     ray: Ray,
     maximumDistance: number | null = null,
@@ -130,9 +118,39 @@ export class CollisionsManager {
     let minimumHit: CollisionMeshState | null = null;
     let minimumNormal: Vect3 = this.tempMinimalNormal;
     let minimumPoint: Vect3 = this.tempMinimalPoint;
+    // Pre-compute inverse direction for the ray-AABB slab test below.
+    // Division by zero yields ±Infinity, which still produces correct
+    // min/max behavior in the slab test for axis-aligned rays.
+    const ox = ray.origin.x;
+    const oy = ray.origin.y;
+    const oz = ray.origin.z;
+    const invDx = 1 / ray.direction.x;
+    const invDy = 1 / ray.direction.y;
+    const invDz = 1 / ray.direction.z;
+    const cullEnabled = this.cullingEnabled;
     for (const [, collisionMeshState] of this.collisionMeshState) {
-      if (this.cullingEnabled && !this.isMeshWithinCullingDistance(collisionMeshState)) {
-        continue;
+      // Tight ray-vs-AABB cull (slab test). Replaces the legacy
+      // character-radius sphere cull — at high group counts the per-group
+      // matrix invert + BVH descent below dominates without it.
+      if (cullEnabled && this.exemptFromCulling !== collisionMeshState) {
+        const tx1 = (collisionMeshState.worldMinX - ox) * invDx;
+        const tx2 = (collisionMeshState.worldMaxX - ox) * invDx;
+        let tmin = tx1 < tx2 ? tx1 : tx2;
+        let tmax = tx1 > tx2 ? tx1 : tx2;
+        const ty1 = (collisionMeshState.worldMinY - oy) * invDy;
+        const ty2 = (collisionMeshState.worldMaxY - oy) * invDy;
+        const tyMin = ty1 < ty2 ? ty1 : ty2;
+        const tyMax = ty1 > ty2 ? ty1 : ty2;
+        if (tyMin > tmin) tmin = tyMin;
+        if (tyMax < tmax) tmax = tyMax;
+        const tz1 = (collisionMeshState.worldMinZ - oz) * invDz;
+        const tz2 = (collisionMeshState.worldMaxZ - oz) * invDz;
+        const tzMin = tz1 < tz2 ? tz1 : tz2;
+        const tzMax = tz1 > tz2 ? tz1 : tz2;
+        if (tzMin > tmin) tmin = tzMin;
+        if (tzMax < tmax) tmax = tzMax;
+        if (tmax < 0 || tmin > tmax) continue;
+        if (maximumDistance !== null && tmin > maximumDistance) continue;
       }
 
       const invertedMatrix = this.tempMatrix.copy(collisionMeshState.matrix).invert();
@@ -207,7 +225,21 @@ export class CollisionsManager {
       localScale,
       trackCollisions: mElement !== undefined,
       boundingSphereRadius,
+      localMinX: minX,
+      localMinY: minY,
+      localMinZ: minZ,
+      localMaxX: maxX,
+      localMaxY: maxY,
+      localMaxZ: maxZ,
+      // Filled in by recomputeWorldAABB just below.
+      worldMinX: 0,
+      worldMinY: 0,
+      worldMinZ: 0,
+      worldMaxX: 0,
+      worldMaxY: 0,
+      worldMaxZ: 0,
     };
+    this.recomputeWorldAABB(meshState);
     this.collisionMeshState.set(group, meshState);
   }
 
@@ -218,7 +250,51 @@ export class CollisionsManager {
       meshState.localScale.x = localScale.x;
       meshState.localScale.y = localScale.y;
       meshState.localScale.z = localScale.z;
+      this.recomputeWorldAABB(meshState);
     }
+  }
+
+  /**
+   * Refresh `meshState.world{Min,Max}{X,Y,Z}` from the cached local AABB and
+   * the current `matrix`. Transforms the 8 corners of the local box and
+   * takes the axis-aligned bound — the tightest correct world-AABB for an
+   * arbitrarily-rotated mesh. Called on add and on every matrix change;
+   * never per-frame.
+   */
+  private recomputeWorldAABB(s: CollisionMeshState): void {
+    const m = s.matrix.data;
+    const lminX = s.localMinX,
+      lminY = s.localMinY,
+      lminZ = s.localMinZ;
+    const lmaxX = s.localMaxX,
+      lmaxY = s.localMaxY,
+      lmaxZ = s.localMaxZ;
+    let minX = Infinity,
+      minY = Infinity,
+      minZ = Infinity;
+    let maxX = -Infinity,
+      maxY = -Infinity,
+      maxZ = -Infinity;
+    for (let i = 0; i < 8; i++) {
+      const x = i & 1 ? lmaxX : lminX;
+      const y = i & 2 ? lmaxY : lminY;
+      const z = i & 4 ? lmaxZ : lminZ;
+      const wx = m[0] * x + m[4] * y + m[8] * z + m[12];
+      const wy = m[1] * x + m[5] * y + m[9] * z + m[13];
+      const wz = m[2] * x + m[6] * y + m[10] * z + m[14];
+      if (wx < minX) minX = wx;
+      if (wx > maxX) maxX = wx;
+      if (wy < minY) minY = wy;
+      if (wy > maxY) maxY = wy;
+      if (wz < minZ) minZ = wz;
+      if (wz > maxZ) maxZ = wz;
+    }
+    s.worldMinX = minX;
+    s.worldMinY = minY;
+    s.worldMinZ = minZ;
+    s.worldMaxX = maxX;
+    s.worldMaxY = maxY;
+    s.worldMaxZ = maxZ;
   }
 
   public removeMeshesGroup(group: CollisionSourceRef): void {
@@ -339,10 +415,32 @@ export class CollisionsManager {
         position: { x: number; y: number; z: number };
       }
     >();
+    // Capsule's world-space AABB. Computed once and re-used as a tight
+    // per-group cull below — the per-group setup inside `applyCollider`
+    // (matrix invert + box transform) is expensive enough that scanning
+    // all groups linearly costs ~30 ms per 1000 groups before any actual
+    // collision work. A cheap AABB-vs-AABB rejection skips the setup for
+    // groups that can't possibly intersect the capsule.
+    const sx = tempSegment.start.x;
+    const sy = tempSegment.start.y;
+    const sz = tempSegment.start.z;
+    const ex = tempSegment.end.x;
+    const ey = tempSegment.end.y;
+    const ez = tempSegment.end.z;
+    const capMinX = (sx < ex ? sx : ex) - radius;
+    const capMinY = (sy < ey ? sy : ey) - radius;
+    const capMinZ = (sz < ez ? sz : ez) - radius;
+    const capMaxX = (sx > ex ? sx : ex) + radius;
+    const capMaxY = (sy > ey ? sy : ey) + radius;
+    const capMaxZ = (sz > ez ? sz : ez) + radius;
     for (const meshState of this.collisionMeshState.values()) {
-      // Skip meshes that are too far from the character
-      if (this.cullingEnabled && !this.isMeshWithinCullingDistance(meshState)) {
-        continue;
+      // Tight world-AABB cull. Strictly tighter than the legacy
+      // character-radius sphere cull, and the only thing that makes
+      // physics scale to thousands of groups.
+      if (this.cullingEnabled && this.exemptFromCulling !== meshState) {
+        if (capMaxX < meshState.worldMinX || capMinX > meshState.worldMaxX) continue;
+        if (capMaxY < meshState.worldMinY || capMinY > meshState.worldMaxY) continue;
+        if (capMaxZ < meshState.worldMinZ || capMinZ > meshState.worldMaxZ) continue;
       }
 
       const collisionPosition = this.applyCollider(tempSegment, radius, meshState);

--- a/packages/3d-web-client-core/src/rendering/IRenderer.ts
+++ b/packages/3d-web-client-core/src/rendering/IRenderer.ts
@@ -48,6 +48,13 @@ export type RenderState = {
   updatedCharacterDescriptions: number[];
   removedConnectionIds: number[];
   cameraTransform: CameraTransform;
+  /**
+   * Local user's network connection id (same value as
+   * `CharacterManager.getLocalConnectionId()`). null before the local
+   * character has spawned. Renderers that own the remote-character
+   * pipeline (e.g. narwhal) should use this with `remoteUserStates`
+   * to identify the local entry to skip.
+   */
   localCharacterId: number | null;
   deltaTimeSeconds: number;
   /**
@@ -58,13 +65,6 @@ export type RenderState = {
    * relying on CharacterManager's per-frame processing.
    */
   remoteUserStates?: ReadonlyMap<number, CharacterState>;
-  /**
-   * Local connection ID. Optional — populated by
-   * Networked3dWebExperienceClient alongside `remoteUserStates`.
-   * Renderer wrappers consuming the network truth directly use this to
-   * filter out the local player from remote-character pipelines.
-   */
-  localConnectionId?: number;
 };
 
 export type EnvironmentConfiguration = {

--- a/packages/3d-web-client-core/src/rendering/IRenderer.ts
+++ b/packages/3d-web-client-core/src/rendering/IRenderer.ts
@@ -1,5 +1,5 @@
 import { AnimationWeights, AnimationTimes } from "../character/AnimationMixer";
-import { AnimationState } from "../character/CharacterState";
+import { AnimationState, CharacterState } from "../character/CharacterState";
 import { AnimationConfig } from "../character/types";
 import { EulXYZ, Vect3 } from "../math";
 
@@ -50,6 +50,21 @@ export type RenderState = {
   cameraTransform: CameraTransform;
   localCharacterId: number | null;
   deltaTimeSeconds: number;
+  /**
+   * Live network-truth map of remote-user states (CharacterState per
+   * connectionId). Optional — populated by Networked3dWebExperienceClient
+   * so renderer wrappers that own their own remote-character pipeline
+   * (e.g. narwhal) can read directly from network truth instead of
+   * relying on CharacterManager's per-frame processing.
+   */
+  remoteUserStates?: ReadonlyMap<number, CharacterState>;
+  /**
+   * Local connection ID. Optional — populated by
+   * Networked3dWebExperienceClient alongside `remoteUserStates`.
+   * Renderer wrappers consuming the network truth directly use this to
+   * filter out the local player from remote-character pipelines.
+   */
+  localConnectionId?: number;
 };
 
 export type EnvironmentConfiguration = {

--- a/packages/3d-web-client-core/src/rendering/IRenderer.ts
+++ b/packages/3d-web-client-core/src/rendering/IRenderer.ts
@@ -65,6 +65,21 @@ export type RenderState = {
    * relying on CharacterManager's per-frame processing.
    */
   remoteUserStates?: ReadonlyMap<number, CharacterState>;
+  /**
+   * Resolves identity (username, character description, colors) for a
+   * remote connection id. Stable closure — external renderer wrappers
+   * (e.g. narwhal) read it once on first frame and cache the reference.
+   *
+   * Same callback that's passed to `CharacterManager` via config —
+   * exposed here for renderers that own their own remote-character
+   * pipeline and need to resolve identity at spawn time.
+   */
+  getRemoteCharacterInfo?: (id: number) => {
+    userId: string;
+    username: string | null;
+    characterDescription: CharacterDescription | null;
+    colors: Array<[number, number, number]> | null;
+  };
 };
 
 export type EnvironmentConfiguration = {

--- a/packages/3d-web-client-core/src/rendering/IRenderer.ts
+++ b/packages/3d-web-client-core/src/rendering/IRenderer.ts
@@ -48,32 +48,12 @@ export type RenderState = {
   updatedCharacterDescriptions: number[];
   removedConnectionIds: number[];
   cameraTransform: CameraTransform;
-  /**
-   * Local user's network connection id (same value as
-   * `CharacterManager.getLocalConnectionId()`). null before the local
-   * character has spawned. Renderers that own the remote-character
-   * pipeline (e.g. narwhal) should use this with `remoteUserStates`
-   * to identify the local entry to skip.
-   */
+  /** null before the local character has spawned. */
   localCharacterId: number | null;
   deltaTimeSeconds: number;
-  /**
-   * Live network-truth map of remote-user states (CharacterState per
-   * connectionId). Optional — populated by Networked3dWebExperienceClient
-   * so renderer wrappers that own their own remote-character pipeline
-   * (e.g. narwhal) can read directly from network truth instead of
-   * relying on CharacterManager's per-frame processing.
-   */
+  /** Network-truth map for renderers that drive their own remote-character pipeline. */
   remoteUserStates?: ReadonlyMap<number, CharacterState>;
-  /**
-   * Resolves identity (username, character description, colors) for a
-   * remote connection id. Stable closure — external renderer wrappers
-   * (e.g. narwhal) read it once on first frame and cache the reference.
-   *
-   * Same callback that's passed to `CharacterManager` via config —
-   * exposed here for renderers that own their own remote-character
-   * pipeline and need to resolve identity at spawn time.
-   */
+  /** Stable identity-resolver callback; safe to pointer-compare across frames. */
   getRemoteCharacterInfo?: (id: number) => {
     userId: string;
     username: string | null;

--- a/packages/3d-web-client-core/test/character/AnimationMixer.test.ts
+++ b/packages/3d-web-client-core/test/character/AnimationMixer.test.ts
@@ -221,4 +221,19 @@ describe("AnimationMixer", () => {
       expect(sum).toBeCloseTo(1.0, 5);
     }
   });
+
+  test("emote state participates in transitions, time accumulation, and weight sum", () => {
+    const mixer = new AnimationMixer();
+    mixer.setTargetState(AnimationState.emote);
+    mixer.update(0.2); // past the 0.15s transition — weights now fully on emote
+
+    const weights = mixer.getWeights();
+    expect(weights[AnimationState.emote]).toBe(1.0);
+    expect(weights[AnimationState.idle]).toBe(0);
+
+    // Subsequent updates accumulate time on the emote slot.
+    mixer.update(0.1);
+    const times = mixer.getAnimationTimes();
+    expect(times[AnimationState.emote]).toBeCloseTo(0.1, 5);
+  });
 });

--- a/packages/3d-web-client-core/test/character/CharacterManager.test.ts
+++ b/packages/3d-web-client-core/test/character/CharacterManager.test.ts
@@ -129,6 +129,16 @@ describe("CharacterManager", () => {
     expect(manager.getLocalConnectionId()).toBe(42);
   });
 
+  test("getRemoteUserStates returns the live config map", () => {
+    expect(manager.getRemoteUserStates()).toBe(config.remoteUserStates);
+    config.remoteUserStates.set(7, {
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { eulerY: 0 },
+      state: AnimationState.idle,
+    });
+    expect(manager.getRemoteUserStates().has(7)).toBe(true);
+  });
+
   test("spawnLocalCharacter creates local controller", () => {
     manager.spawnLocalCharacter(1, new Vect3(5, 10, 15));
     expect(manager.localController).not.toBeNull();

--- a/packages/3d-web-client-core/test/character/CharacterManager.test.ts
+++ b/packages/3d-web-client-core/test/character/CharacterManager.test.ts
@@ -68,7 +68,6 @@ function createMockConfig(overrides?: Partial<CharacterManagerConfig>): Characte
     collisionsManager: {
       applyColliders: jest.fn<any>().mockReturnValue({ onGround: true }),
       raycastFirst: jest.fn<any>().mockReturnValue(null),
-      setCharacterPosition: jest.fn(),
       setCullingEnabled: jest.fn(),
       setExemptFromCulling: jest.fn(),
     } as any,

--- a/packages/3d-web-client-core/test/character/CharacterManager.test.ts
+++ b/packages/3d-web-client-core/test/character/CharacterManager.test.ts
@@ -168,6 +168,21 @@ describe("CharacterManager", () => {
     expect(states.get(2)!.isLocal).toBe(false);
   });
 
+  test("update skips remote character processing when skipRemoteCharacterUpdate is true", () => {
+    const skipConfig = createMockConfig({ skipRemoteCharacterUpdate: true });
+    const skipManager = new CharacterManagerReloaded(skipConfig);
+    skipManager.setLocalConnectionId(1);
+    skipConfig.remoteUserStates.set(2, {
+      position: { x: 10, y: 0, z: 0 },
+      rotation: { eulerY: 0 },
+      state: AnimationState.idle,
+    });
+    skipManager.update(0.016, 0);
+    expect(skipManager.remoteCharacters.has(2)).toBe(false);
+    const states = skipManager.getAllCharacterStates();
+    expect(states.has(2)).toBe(false);
+  });
+
   test("update skips local client ID from remote states", () => {
     manager.spawnLocalCharacter(1);
     config.remoteUserStates.set(1, {

--- a/packages/3d-web-client-core/test/character/CharacterState.test.ts
+++ b/packages/3d-web-client-core/test/character/CharacterState.test.ts
@@ -11,12 +11,13 @@ describe("CharacterState", () => {
     expect(AnimationState.air).toBe(4);
     expect(AnimationState.airToGround).toBe(5);
     expect(AnimationState.doubleJump).toBe(6);
+    expect(AnimationState.emote).toBe(7);
   });
 
-  test("AnimationState enum has exactly 7 values", () => {
+  test("AnimationState enum has exactly 8 values", () => {
     // numeric enums have forward and reverse mappings
     const names = Object.keys(AnimationState).filter((k) => isNaN(Number(k)));
-    expect(names).toHaveLength(7);
+    expect(names).toHaveLength(8);
   });
 
   test("AnimationState names match expected string values", () => {
@@ -27,6 +28,7 @@ describe("CharacterState", () => {
     expect(AnimationState[4]).toBe("air");
     expect(AnimationState[5]).toBe("airToGround");
     expect(AnimationState[6]).toBe("doubleJump");
+    expect(AnimationState[7]).toBe("emote");
   });
 
   test("CharacterState type can be constructed", () => {

--- a/packages/3d-web-client-core/test/character/LocalController.test.ts
+++ b/packages/3d-web-client-core/test/character/LocalController.test.ts
@@ -17,7 +17,6 @@ function createMockConfig(overrides?: Partial<LocalControllerConfig>): LocalCont
     collisionsManager: {
       applyColliders: jest.fn<any>(),
       raycastFirst: jest.fn<any>().mockReturnValue(null),
-      setCharacterPosition: jest.fn(),
       setCullingEnabled: jest.fn(),
       setExemptFromCulling: jest.fn(),
     } as any,
@@ -225,7 +224,6 @@ describe("LocalController", () => {
   describe("update", () => {
     test("calls collisions manager methods", () => {
       controller.update(0.016);
-      expect(config.collisionsManager.setCharacterPosition).toHaveBeenCalled();
       expect(config.collisionsManager.setExemptFromCulling).toHaveBeenCalled();
       expect(config.collisionsManager.applyColliders).toHaveBeenCalled();
     });

--- a/packages/3d-web-client-core/test/collisions/CollisionsManager.test.ts
+++ b/packages/3d-web-client-core/test/collisions/CollisionsManager.test.ts
@@ -63,11 +63,6 @@ describe("CollisionsManager", () => {
       // No direct getter, but we can verify by adding a far mesh and raycasting
     });
 
-    test("setCharacterPosition updates position for culling", () => {
-      manager.setCharacterPosition({ x: 10, y: 20, z: 30 });
-      // Position is stored internally for culling distance calculations
-    });
-
     test("setExemptFromCulling accepts null", () => {
       manager.setExemptFromCulling(null);
     });

--- a/packages/3d-web-client-core/test/collisions/CollisionsManager.test.ts
+++ b/packages/3d-web-client-core/test/collisions/CollisionsManager.test.ts
@@ -210,12 +210,32 @@ describe("CollisionsManager", () => {
       expect(result).toBeNull();
     });
 
-    test("raycastFirst culls distant meshes", () => {
+    test("raycastFirst skips meshes whose world AABB the ray misses", () => {
       manager.setCullingEnabled(true);
-      manager.setCharacterPosition({ x: 0, y: 0, z: 0 });
 
       const meshBVH = createMockMeshBVH();
-      const matrix = new Matr4().setPosition(200, 0, 0); // Far away
+      // Mesh at +200x with local AABB (-1..1) → world AABB (199..201, -1..1, -1..1).
+      const matrix = new Matr4().setPosition(200, 0, 0);
+      const source = {};
+
+      manager.addMeshesGroup(source, {
+        meshBVH: meshBVH as any,
+        matrix,
+        localScale: { x: 1, y: 1, z: 1 },
+      });
+
+      // Ray at x=0 going down — never enters the AABB on the x slab.
+      const ray = new Ray(new Vect3(0, 10, 0), new Vect3(0, -1, 0));
+      manager.raycastFirst(ray);
+      expect(meshBVH.raycastFirst).not.toHaveBeenCalled();
+    });
+
+    test("raycastFirst still queries meshes whose world AABB the ray hits", () => {
+      manager.setCullingEnabled(true);
+
+      const meshBVH = createMockMeshBVH();
+      // Same far mesh as above, but cast a ray that enters the AABB.
+      const matrix = new Matr4().setPosition(200, 0, 0);
       const source = {};
 
       manager.addMeshesGroup(source, {
@@ -226,8 +246,7 @@ describe("CollisionsManager", () => {
 
       const ray = new Ray(new Vect3(200, 10, 0), new Vect3(0, -1, 0));
       manager.raycastFirst(ray);
-      // The meshBVH should not have been queried since it's too far
-      expect(meshBVH.raycastFirst).not.toHaveBeenCalled();
+      expect(meshBVH.raycastFirst).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -253,6 +272,131 @@ describe("CollisionsManager", () => {
       const segment = new Line(new Vect3(0, 0, 0), new Vect3(0, 1, 0));
       manager.applyColliders(segment, 0.45);
       expect(meshBVH.shapecast).toHaveBeenCalled();
+    });
+
+    test("skips meshes whose world AABB the capsule cannot overlap", () => {
+      manager.setCullingEnabled(true);
+      const meshBVH = createMockMeshBVH();
+      // Mesh at +50x with local AABB (-1..1) → world AABB (49..51, -1..1, -1..1).
+      const matrix = new Matr4().setPosition(50, 0, 0);
+      const source = {};
+
+      manager.addMeshesGroup(source, {
+        meshBVH: meshBVH as any,
+        matrix,
+        localScale: { x: 1, y: 1, z: 1 },
+      });
+
+      // Capsule near the origin — its expanded AABB is well below x=49 even
+      // accounting for the radius, so the cull should reject the mesh.
+      const segment = new Line(new Vect3(0, 0, 0), new Vect3(0, 1, 0));
+      manager.applyColliders(segment, 0.5);
+      expect(meshBVH.shapecast).not.toHaveBeenCalled();
+    });
+
+    test("queries meshes whose world AABB the capsule overlaps", () => {
+      manager.setCullingEnabled(true);
+      const meshBVH = createMockMeshBVH();
+      const matrix = new Matr4(); // identity → world AABB = local (-1..1)
+      const source = {};
+
+      manager.addMeshesGroup(source, {
+        meshBVH: meshBVH as any,
+        matrix,
+        localScale: { x: 1, y: 1, z: 1 },
+      });
+
+      // Capsule sits inside the AABB.
+      const segment = new Line(new Vect3(0, 0, 0), new Vect3(0, 1, 0));
+      manager.applyColliders(segment, 0.5);
+      expect(meshBVH.shapecast).toHaveBeenCalled();
+    });
+  });
+
+  describe("world AABB cache", () => {
+    test("addMeshesGroup caches a world AABB matching the matrix translation", () => {
+      const meshBVH = createMockMeshBVH(); // local bounds (-1..1)
+      const matrix = new Matr4().setPosition(10, 5, -3);
+      const source = {};
+
+      manager.addMeshesGroup(source, {
+        meshBVH: meshBVH as any,
+        matrix,
+        localScale: { x: 1, y: 1, z: 1 },
+      });
+
+      const state = manager.collisionMeshState.get(source)!;
+      expect(state.worldMinX).toBeCloseTo(9, 5);
+      expect(state.worldMaxX).toBeCloseTo(11, 5);
+      expect(state.worldMinY).toBeCloseTo(4, 5);
+      expect(state.worldMaxY).toBeCloseTo(6, 5);
+      expect(state.worldMinZ).toBeCloseTo(-4, 5);
+      expect(state.worldMaxZ).toBeCloseTo(-2, 5);
+    });
+
+    test("updateMeshesGroup refreshes the cached world AABB", () => {
+      const meshBVH = createMockMeshBVH();
+      const matrix = new Matr4();
+      const source = {};
+      manager.addMeshesGroup(source, {
+        meshBVH: meshBVH as any,
+        matrix,
+        localScale: { x: 1, y: 1, z: 1 },
+      });
+
+      const moved = new Matr4().setPosition(100, 0, 0);
+      manager.updateMeshesGroup(source, moved, { x: 1, y: 1, z: 1 });
+
+      const state = manager.collisionMeshState.get(source)!;
+      expect(state.worldMinX).toBeCloseTo(99, 5);
+      expect(state.worldMaxX).toBeCloseTo(101, 5);
+    });
+  });
+
+  describe("raycastAll", () => {
+    test("returns hits sorted by distance, one per group", () => {
+      manager.setCullingEnabled(false);
+
+      const nearBVH = createMockMeshBVH();
+      nearBVH.raycastFirst.mockReturnValue({
+        // Mesh-local hit at y=0; matrix is identity-translated, so distance is the
+        // ray's segment length from origin (0,10,0) to (0,0,5) = sqrt(125) ≈ 11.18.
+        point: { x: 0, y: 0, z: 5, copy: jest.fn().mockReturnThis() },
+        normal: { x: 0, y: 1, z: 0, copy: jest.fn().mockReturnThis() },
+        distance: 5,
+      });
+      const farBVH = createMockMeshBVH();
+      farBVH.raycastFirst.mockReturnValue({
+        // Translated by +20 on y → distance from origin is sqrt(400+225) = 25
+        point: { x: 0, y: 0, z: 15, copy: jest.fn().mockReturnThis() },
+        normal: { x: 0, y: 1, z: 0, copy: jest.fn().mockReturnThis() },
+        distance: 5,
+      });
+
+      manager.addMeshesGroup(
+        {},
+        { meshBVH: farBVH as any, matrix: new Matr4(), localScale: { x: 1, y: 1, z: 1 } },
+      );
+      manager.addMeshesGroup(
+        {},
+        { meshBVH: nearBVH as any, matrix: new Matr4(), localScale: { x: 1, y: 1, z: 1 } },
+      );
+
+      const ray = new Ray(new Vect3(0, 10, 0), new Vect3(0, 0, 1));
+      const results = manager.raycastAll(ray);
+      expect(results.length).toBe(2);
+      expect(results[0].distance).toBeLessThanOrEqual(results[1].distance);
+    });
+
+    test("returns empty array when no groups produce hits", () => {
+      const meshBVH = createMockMeshBVH();
+      meshBVH.raycastFirst.mockReturnValue(null);
+      manager.addMeshesGroup(
+        {},
+        { meshBVH: meshBVH as any, matrix: new Matr4(), localScale: { x: 1, y: 1, z: 1 } },
+      );
+      const ray = new Ray(new Vect3(0, 10, 0), new Vect3(0, -1, 0));
+      expect(manager.raycastAll(ray)).toEqual([]);
     });
   });
 });

--- a/packages/3d-web-experience-bridge/src/AvatarController.ts
+++ b/packages/3d-web-experience-bridge/src/AvatarController.ts
@@ -157,9 +157,6 @@ export class AvatarController extends EventEmitter {
 
     // Update camera position for LocalController's azimuthal angle calculation
     this.cameraManager.setCharacterPosition(this.currentPosition);
-    this.collisionsManager.setCharacterPosition(
-      new Vect3(this.currentPosition.x, this.currentPosition.y, this.currentPosition.z),
-    );
 
     // Run the same physics as the human client with fixed timestep
     this.localController.update(FIXED_DELTA_TIME);

--- a/packages/3d-web-experience-bridge/test/HeadlessMMLScene.test.ts
+++ b/packages/3d-web-experience-bridge/test/HeadlessMMLScene.test.ts
@@ -24,7 +24,6 @@ vi.mock("@mml-io/3d-web-client-core", () => ({
   CollisionsManager: vi.fn().mockImplementation(function () {
     return {
       addMeshesGroup: vi.fn(),
-      setCharacterPosition: vi.fn(),
       updateMeshesGroup: vi.fn(),
       removeMeshesGroup: vi.fn(),
     };

--- a/packages/3d-web-experience-bridge/test/SurfaceAnalyzer.test.ts
+++ b/packages/3d-web-experience-bridge/test/SurfaceAnalyzer.test.ts
@@ -11,7 +11,6 @@ vi.mock("@mml-io/3d-web-client-core", () => ({
   CollisionsManager: vi.fn().mockImplementation(function () {
     return {
       addMeshesGroup: vi.fn(),
-      setCharacterPosition: vi.fn(),
       updateMeshesGroup: vi.fn(),
       removeMeshesGroup: vi.fn(),
     };

--- a/packages/3d-web-experience-bridge/test/collision-detection.test.ts
+++ b/packages/3d-web-experience-bridge/test/collision-detection.test.ts
@@ -601,9 +601,6 @@ describe("custom types vs Three.js types collision comparison", { timeout: 60000
     const sourceRef = {};
     cm.addMeshesGroup(sourceRef, { meshBVH, matrix, localScale });
 
-    // Set character position for culling
-    cm.setCharacterPosition({ x: position.x, y: position.y, z: position.z });
-
     // Build the capsule segment using custom Line (matching LocalController)
     const capsuleSegment = new CoreLine(
       new Vect3(position.x, position.y + CAPSULE_RADIUS, position.z),
@@ -785,8 +782,6 @@ describe("custom types vs Three.js types collision comparison", { timeout: 60000
 
       const sourceRef = {};
       cm.addMeshesGroup(sourceRef, { meshBVH: data.meshBVH, matrix, localScale });
-      cm.setCharacterPosition({ x: pos.x, y: pos.y, z: pos.z });
-
       const capsuleSegment = new CoreLine(
         new Vect3(pos.x, pos.y + CAPSULE_RADIUS, pos.z),
         new Vect3(pos.x, pos.y + CAPSULE_SEGMENT_END_Y + CAPSULE_RADIUS, pos.z),

--- a/packages/3d-web-experience-bridge/test/index-extended.test.ts
+++ b/packages/3d-web-experience-bridge/test/index-extended.test.ts
@@ -51,7 +51,6 @@ vi.mock("@mml-io/3d-web-client-core", () => ({
   CollisionsManager: vi.fn().mockImplementation(function () {
     return {
       addMeshesGroup: vi.fn(),
-      setCharacterPosition: vi.fn(),
       updateMeshesGroup: vi.fn(),
       removeMeshesGroup: vi.fn(),
     };

--- a/packages/3d-web-experience-bridge/test/index.test.ts
+++ b/packages/3d-web-experience-bridge/test/index.test.ts
@@ -36,7 +36,6 @@ vi.mock("@mml-io/3d-web-client-core", () => ({
   CollisionsManager: vi.fn().mockImplementation(function () {
     return {
       addMeshesGroup: vi.fn(),
-      setCharacterPosition: vi.fn(),
       updateMeshesGroup: vi.fn(),
       removeMeshesGroup: vi.fn(),
     };

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -72,7 +72,7 @@ export type Networked3dWebExperienceClientConfig = {
    * processing — the consumer's renderer wrapper (e.g. narwhal) is expected
    * to own the remote-character pipeline and read network state directly
    * via the wrapper's update path. The live `remoteUserStates` and
-   * `localConnectionId` are forwarded to the renderer through `RenderState`
+   * `localCharacterId` are forwarded to the renderer through `RenderState`
    * so the wrapper can drive its own pipeline. Default false.
    */
   skipRemoteCharacterUpdate?: boolean;
@@ -793,7 +793,6 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       localCharacterId: this.characterManager.getLocalConnectionId(),
       deltaTimeSeconds: this.fixedDeltaTime,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
-      localConnectionId: this.characterManager.getLocalConnectionId(),
     };
 
     // Render the actual frame using the associated renderer

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -68,12 +68,9 @@ export type Networked3dWebExperienceClientConfig = {
    */
   plugins?: UIPlugin[];
   /**
-   * When true, the underlying CharacterManager skips its remote-character
-   * processing — the consumer's renderer wrapper (e.g. narwhal) is expected
-   * to own the remote-character pipeline and read network state directly
-   * via the wrapper's update path. The live `remoteUserStates` and
-   * `localCharacterId` are forwarded to the renderer through `RenderState`
-   * so the wrapper can drive its own pipeline. Default false.
+   * When true, CharacterManager skips its remote-character loop and the
+   * consumer's renderer wrapper (e.g. narwhal) is expected to drive remote
+   * characters from `remoteUserStates` on RenderState.
    */
   skipRemoteCharacterUpdate?: boolean;
 } & UpdatableConfig;
@@ -589,19 +586,9 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
     }
   }
 
-  // Cache the UserData wrapper per connectionId so the per-frame
-  // CharacterManager.update path (which calls characterResolve once per
-  // remote character per frame) doesn't allocate a new object literal each
-  // call. With N remote characters at 60Hz this is N×60 allocations/sec
-  // saved. Invalidates whenever any of the underlying user fields change.
-  private resolvedCharacterCache = new Map<number, UserData>();
-
-  // Initialised once as a class-property arrow so it is passed by stable
-  // identity each frame to RenderState.getRemoteCharacterInfo. External
-  // renderer wrappers (e.g. narwhal's NarwhalWorldRenderer) pointer-compare
-  // the resolver and only re-wire it on identity change; an inline arrow at
-  // the per-frame update() site would defeat that cache and re-wire every
-  // frame.
+  // Stable identity — narwhal pointer-compares `getRemoteCharacterInfo`
+  // and re-wires its cache on change, so an inline arrow per frame would
+  // defeat the cache.
   private readonly boundResolveCharacterData = (id: number): UserData =>
     this.resolveCharacterData(id);
 
@@ -611,25 +598,12 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       throw new Error(`Failed to resolve user for connectionId ${connectionId}`);
     }
 
-    const cached = this.resolvedCharacterCache.get(connectionId);
-    if (
-      cached &&
-      cached.userId === user.userId &&
-      cached.username === user.username &&
-      cached.characterDescription === user.characterDescription &&
-      cached.colors === user.colors
-    ) {
-      return cached;
-    }
-
-    const fresh: UserData = {
+    return {
       userId: user.userId,
       username: user.username,
       characterDescription: user.characterDescription,
       colors: user.colors,
     };
-    this.resolvedCharacterCache.set(connectionId, fresh);
-    return fresh;
   }
 
   private onNetworkUpdate(update: NetworkUpdate): void {
@@ -643,7 +617,6 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       });
       this.userProfiles.delete(connId);
       this.remoteUserStates.delete(connId);
-      this.resolvedCharacterCache.delete(connId);
     }
     for (const [connId, userData] of addedConnectionIds) {
       this.userProfiles.set(connId, userData.userState);
@@ -802,18 +775,9 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       removedConnectionIds,
       cameraTransform: this.cachedCameraTransform,
       localCharacterId: this.characterManager.getLocalConnectionId(),
-      // Time advanced by physics since the last render: N steps × the
-      // fixed step. This is the right value for renderers that drive
-      // animations / smoothing from `deltaTimeSeconds`, in both regimes:
-      //   - display rate ≥ physics rate (common case): exactly one step
-      //     ran, dt == fixedDeltaTime == real interval between renders.
-      //   - display rate < physics rate (GPU-bound): N steps ran,
-      //     dt == N × fixedDeltaTime == total simulation time advanced.
-      // Using raw `elapsedSeconds` (time since the last rAF tick) instead
-      // under-counts on high-refresh displays, because render is gated on
-      // `physicsUpdated` so it fires every other (or every Nth) rAF —
-      // `elapsedSeconds` then reflects one rAF interval, not the real
-      // gap to the previous render.
+      // Render is gated on physicsUpdated, so raw rAF elapsed time
+      // under-counts on high-refresh displays. Use the simulated time
+      // actually advanced this frame (N × fixedDeltaTime).
       deltaTimeSeconds: physicsStepsThisFrame * this.fixedDeltaTime,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
       getRemoteCharacterInfo: this.boundResolveCharacterData,

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -800,7 +800,15 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       removedConnectionIds,
       cameraTransform: this.cachedCameraTransform,
       localCharacterId: this.characterManager.getLocalConnectionId(),
-      deltaTimeSeconds: this.fixedDeltaTime,
+      // Real elapsed wall-clock time since the last render — clamped above
+      // to 0.1 s. Use this rather than `fixedDeltaTime`: when the physics
+      // loop above runs multiple steps per render (display rate < target
+      // physics rate), passing `fixedDeltaTime` would under-count the real
+      // time consumed and slow down per-frame animations / smoothing
+      // visibly. Renderers that need a fixed step (deterministic physics)
+      // can re-derive it; renderers that drive animations want the real
+      // elapsed time.
+      deltaTimeSeconds: elapsedSeconds,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
       getRemoteCharacterInfo: this.boundResolveCharacterData,
     };

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -67,6 +67,15 @@ export type Networked3dWebExperienceClientConfig = {
    * controls, etc.) that participates in the standard plugin lifecycle.
    */
   plugins?: UIPlugin[];
+  /**
+   * When true, the underlying CharacterManager skips its remote-character
+   * processing — the consumer's renderer wrapper (e.g. narwhal) is expected
+   * to own the remote-character pipeline and read network state directly
+   * via the wrapper's update path. The live `remoteUserStates` and
+   * `localConnectionId` are forwarded to the renderer through `RenderState`
+   * so the wrapper can drive its own pipeline. Default false.
+   */
+  skipRemoteCharacterUpdate?: boolean;
 } & UpdatableConfig;
 
 /**
@@ -361,6 +370,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
         return this.resolveCharacterData(connectionId);
       },
       updateURLLocation: this.config.updateURLLocation !== false,
+      skipRemoteCharacterUpdate: this.config.skipRemoteCharacterUpdate ?? false,
     });
 
     this.loadingScreen = new LoadingScreen(this.loadingProgressManager, this.config.loadingScreen);
@@ -782,6 +792,8 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       cameraTransform: this.cachedCameraTransform,
       localCharacterId: this.characterManager.getLocalConnectionId(),
       deltaTimeSeconds: this.fixedDeltaTime,
+      remoteUserStates: this.characterManager.getRemoteUserStates(),
+      localConnectionId: this.characterManager.getLocalConnectionId(),
     };
 
     // Render the actual frame using the associated renderer

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -579,18 +579,38 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
     }
   }
 
+  // Cache the UserData wrapper per connectionId so the per-frame
+  // CharacterManager.update path (which calls characterResolve once per
+  // remote character per frame) doesn't allocate a new object literal each
+  // call. With N remote characters at 60Hz this is N×60 allocations/sec
+  // saved. Invalidates whenever any of the underlying user fields change.
+  private resolvedCharacterCache = new Map<number, UserData>();
+
   private resolveCharacterData(connectionId: number): UserData {
     const user = this.userProfiles.get(connectionId);
     if (!user) {
       throw new Error(`Failed to resolve user for connectionId ${connectionId}`);
     }
 
-    return {
+    const cached = this.resolvedCharacterCache.get(connectionId);
+    if (
+      cached &&
+      cached.userId === user.userId &&
+      cached.username === user.username &&
+      cached.characterDescription === user.characterDescription &&
+      cached.colors === user.colors
+    ) {
+      return cached;
+    }
+
+    const fresh: UserData = {
       userId: user.userId,
       username: user.username,
       characterDescription: user.characterDescription,
       colors: user.colors,
     };
+    this.resolvedCharacterCache.set(connectionId, fresh);
+    return fresh;
   }
 
   private onNetworkUpdate(update: NetworkUpdate): void {
@@ -604,6 +624,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       });
       this.userProfiles.delete(connId);
       this.remoteUserStates.delete(connId);
+      this.resolvedCharacterCache.delete(connId);
     }
     for (const [connId, userData] of addedConnectionIds) {
       this.userProfiles.set(connId, userData.userState);

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -596,6 +596,15 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
   // saved. Invalidates whenever any of the underlying user fields change.
   private resolvedCharacterCache = new Map<number, UserData>();
 
+  // Initialised once as a class-property arrow so it is passed by stable
+  // identity each frame to RenderState.getRemoteCharacterInfo. External
+  // renderer wrappers (e.g. narwhal's NarwhalWorldRenderer) pointer-compare
+  // the resolver and only re-wire it on identity change; an inline arrow at
+  // the per-frame update() site would defeat that cache and re-wire every
+  // frame.
+  private readonly boundResolveCharacterData = (id: number): UserData =>
+    this.resolveCharacterData(id);
+
   private resolveCharacterData(connectionId: number): UserData {
     const user = this.userProfiles.get(connectionId);
     if (!user) {
@@ -793,7 +802,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       localCharacterId: this.characterManager.getLocalConnectionId(),
       deltaTimeSeconds: this.fixedDeltaTime,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
-      getRemoteCharacterInfo: (id: number) => this.resolveCharacterData(id),
+      getRemoteCharacterInfo: this.boundResolveCharacterData,
     };
 
     // Render the actual frame using the associated renderer

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -69,8 +69,8 @@ export type Networked3dWebExperienceClientConfig = {
   plugins?: UIPlugin[];
   /**
    * When true, CharacterManager skips its remote-character loop and the
-   * consumer's renderer wrapper (e.g. narwhal) is expected to drive remote
-   * characters from `remoteUserStates` on RenderState.
+   * renderer is expected to drive remote characters from `remoteUserStates`
+   * on RenderState.
    */
   skipRemoteCharacterUpdate?: boolean;
 } & UpdatableConfig;
@@ -586,8 +586,8 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
     }
   }
 
-  // Stable identity — narwhal pointer-compares `getRemoteCharacterInfo`
-  // and re-wires its cache on change, so an inline arrow per frame would
+  // Stable identity — renderers may pointer-compare `getRemoteCharacterInfo`
+  // and re-wire caches on change, so an inline arrow per frame would
   // defeat the cache.
   private readonly boundResolveCharacterData = (id: number): UserData =>
     this.resolveCharacterData(id);

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -793,6 +793,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       localCharacterId: this.characterManager.getLocalConnectionId(),
       deltaTimeSeconds: this.fixedDeltaTime,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
+      getRemoteCharacterInfo: (id: number) => this.resolveCharacterData(id),
     };
 
     // Render the actual frame using the associated renderer

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -737,6 +737,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
 
     // Track if any physics updates occurred this frame
     let physicsUpdated = false;
+    let physicsStepsThisFrame = 0;
     const updatedCharacterDescriptions: number[] = [];
     const removedConnectionIds: number[] = [];
 
@@ -762,6 +763,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
 
       this.accumulatedTime -= this.fixedDeltaTime;
       physicsUpdated = true;
+      physicsStepsThisFrame++;
     }
 
     // Only render if physics was updated (limits render rate to physics rate)
@@ -800,15 +802,19 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       removedConnectionIds,
       cameraTransform: this.cachedCameraTransform,
       localCharacterId: this.characterManager.getLocalConnectionId(),
-      // Real elapsed wall-clock time since the last render — clamped above
-      // to 0.1 s. Use this rather than `fixedDeltaTime`: when the physics
-      // loop above runs multiple steps per render (display rate < target
-      // physics rate), passing `fixedDeltaTime` would under-count the real
-      // time consumed and slow down per-frame animations / smoothing
-      // visibly. Renderers that need a fixed step (deterministic physics)
-      // can re-derive it; renderers that drive animations want the real
-      // elapsed time.
-      deltaTimeSeconds: elapsedSeconds,
+      // Time advanced by physics since the last render: N steps × the
+      // fixed step. This is the right value for renderers that drive
+      // animations / smoothing from `deltaTimeSeconds`, in both regimes:
+      //   - display rate ≥ physics rate (common case): exactly one step
+      //     ran, dt == fixedDeltaTime == real interval between renders.
+      //   - display rate < physics rate (GPU-bound): N steps ran,
+      //     dt == N × fixedDeltaTime == total simulation time advanced.
+      // Using raw `elapsedSeconds` (time since the last rAF tick) instead
+      // under-counts on high-refresh displays, because render is gated on
+      // `physicsUpdated` so it fires every other (or every Nth) rAF —
+      // `elapsedSeconds` then reflects one rAF interval, not the real
+      // gap to the previous render.
+      deltaTimeSeconds: physicsStepsThisFrame * this.fixedDeltaTime,
       remoteUserStates: this.characterManager.getRemoteUserStates(),
       getRemoteCharacterInfo: this.boundResolveCharacterData,
     };

--- a/packages/3d-web-user-networking/src/DeltaNetComponentMapping.ts
+++ b/packages/3d-web-user-networking/src/DeltaNetComponentMapping.ts
@@ -57,24 +57,43 @@ export class DeltaNetComponentMapping {
   }
 
   /**
-   * Convert deltanet components back to UserNetworkingClientUpdate
+   * Convert deltanet components back to UserNetworkingClientUpdate.
+   * Allocates a fresh result object — prefer `fromComponentsInto` on hot
+   * paths (per-tick update loop in `UserNetworkingClient`) to mutate a
+   * pre-allocated scratch instead.
    */
   static fromComponents(components: Map<number, bigint>): UserNetworkingClientUpdate {
-    const positionX =
-      Number(components.get(COMPONENT_POSITION_X) || BigInt(0)) / positionMultiplier;
-    const positionY =
-      Number(components.get(COMPONENT_POSITION_Y) || BigInt(0)) / positionMultiplier;
-    const positionZ =
-      Number(components.get(COMPONENT_POSITION_Z) || BigInt(0)) / positionMultiplier;
-    const eulerY = Number(components.get(COMPONENT_ROTATION_Y) || BigInt(0)) / rotationMultiplier;
+    return DeltaNetComponentMapping.fromComponentsInto(components, {
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { eulerY: 0 },
+      state: 0,
+    });
+  }
 
-    const state = Number(components.get(COMPONENT_STATE) || BigInt(0));
-
-    return {
-      position: { x: positionX, y: positionY, z: positionZ },
-      rotation: { eulerY },
-      state,
-    };
+  /**
+   * Same conversion as `fromComponents` but writes into a caller-provided
+   * `dest` object (mutating its `position`, `rotation`, and `state`
+   * fields in place). Returns `dest` for chaining.
+   *
+   * Used by the per-tick update loop, which keeps a pool of these
+   * objects keyed by connection id so the hot path stays
+   * allocation-free at 2000 users × 30 Hz.
+   */
+  static fromComponentsInto(
+    components: Map<number, bigint>,
+    dest: UserNetworkingClientUpdate,
+  ): UserNetworkingClientUpdate {
+    const px = components.get(COMPONENT_POSITION_X);
+    const py = components.get(COMPONENT_POSITION_Y);
+    const pz = components.get(COMPONENT_POSITION_Z);
+    const ry = components.get(COMPONENT_ROTATION_Y);
+    const st = components.get(COMPONENT_STATE);
+    dest.position.x = px !== undefined ? Number(px) / positionMultiplier : 0;
+    dest.position.y = py !== undefined ? Number(py) / positionMultiplier : 0;
+    dest.position.z = pz !== undefined ? Number(pz) / positionMultiplier : 0;
+    dest.rotation.eulerY = ry !== undefined ? Number(ry) / rotationMultiplier : 0;
+    dest.state = st !== undefined ? Number(st) : 0;
+    return dest;
   }
 
   /**

--- a/packages/3d-web-user-networking/src/DeltaNetComponentMapping.ts
+++ b/packages/3d-web-user-networking/src/DeltaNetComponentMapping.ts
@@ -71,13 +71,9 @@ export class DeltaNetComponentMapping {
   }
 
   /**
-   * Same conversion as `fromComponents` but writes into a caller-provided
-   * `dest` object (mutating its `position`, `rotation`, and `state`
-   * fields in place). Returns `dest` for chaining.
-   *
-   * Used by the per-tick update loop, which keeps a pool of these
-   * objects keyed by connection id so the hot path stays
-   * allocation-free at 2000 users × 30 Hz.
+   * Mutating variant of `fromComponents` — writes into a caller-provided
+   * `dest`. Used by the per-tick update loop with a per-connection-id
+   * pool to keep the hot path allocation-free.
    */
   static fromComponentsInto(
     components: Map<number, bigint>,

--- a/packages/3d-web-user-networking/src/UserNetworkingClient.ts
+++ b/packages/3d-web-user-networking/src/UserNetworkingClient.ts
@@ -71,6 +71,22 @@ export class UserNetworkingClient {
   private stableIdToConnectionId: Map<number, number> = new Map();
   private userProfiles: Map<number, UserData> = new Map();
   private isAuthenticated = false;
+
+  // Reused across calls to `processNetworkUpdate` (~30 Hz). Cleared at the
+  // start of each call and repopulated. Consumers (notably
+  // `Networked3dWebExperienceClient.onNetworkUpdate`) read these maps
+  // synchronously and don't retain references — safe to reuse.
+  private readonly _addedConnectionIdsScratch = new Map<number, AddedUser>();
+  private readonly _removedConnectionIdsScratch = new Set<number>();
+  private readonly _updatedUsersScratch = new Map<number, UpdatedUser>();
+  // Per-connId pools — one persistent UserNetworkingClientUpdate +
+  // UpdatedUser wrapper per active connection. The pooled
+  // UserNetworkingClientUpdate is also the value `Networked3dWebExperienceClient`
+  // stores into its `remoteUserStates` map, so mutating in place each tick
+  // makes the new values visible without re-allocating the wrapper.
+  // Entries removed from the pool when the connection is removed.
+  private readonly _componentsPool = new Map<number, UserNetworkingClientUpdate>();
+  private readonly _updatedUserPool = new Map<number, UpdatedUser>();
   private pendingUpdate: UserNetworkingClientUpdate;
 
   constructor(
@@ -221,8 +237,14 @@ export class UserNetworkingClient {
     addedStableIdsArray: number[],
     stateUpdates: Array<{ stableId: number; stateId: number; state: Uint8Array }>,
   ): NetworkUpdate {
-    const addedConnectionIds = new Map<number, AddedUser>();
-    const removedConnectionIds = new Set<number>();
+    // Reuse class-owned scratch maps across calls. Consumers must not
+    // retain references past a single tick.
+    const addedConnectionIds = this._addedConnectionIdsScratch;
+    const removedConnectionIds = this._removedConnectionIdsScratch;
+    const updatedUsers = this._updatedUsersScratch;
+    addedConnectionIds.clear();
+    removedConnectionIds.clear();
+    updatedUsers.clear();
 
     for (const stableId of removedStableIds) {
       const connId = this.stableIdToConnectionId.get(stableId);
@@ -234,6 +256,11 @@ export class UserNetworkingClient {
 
         // Remove from stableIdToConnectionId
         this.stableIdToConnectionId.delete(stableId);
+
+        // Drop pooled per-connId scratch — they're tied to a connection's
+        // lifetime, so a new connection on the same id starts fresh.
+        this._componentsPool.delete(connId);
+        this._updatedUserPool.delete(connId);
       } else {
         throw new Error(`No connectionId found for stableId ${stableId}`);
       }
@@ -255,14 +282,20 @@ export class UserNetworkingClient {
       this.stableIdToConnectionId.set(stableId, connId);
       const newProfile = DeltaNetComponentMapping.fromStates(stableUserData.states, this.logger);
       this.userProfiles.set(connId, newProfile);
-      const clientUpdate = DeltaNetComponentMapping.fromComponents(stableUserData.components);
+      // Allocate a per-connId components scratch and seed it from the
+      // component map. Re-used in subsequent update ticks via mutation.
+      const clientUpdate: UserNetworkingClientUpdate = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { eulerY: 0 },
+        state: 0,
+      };
+      DeltaNetComponentMapping.fromComponentsInto(stableUserData.components, clientUpdate);
+      this._componentsPool.set(connId, clientUpdate);
       addedConnectionIds.set(connId, {
         userState: newProfile,
         components: clientUpdate,
       });
     }
-
-    const updatedUsers = new Map<number, UpdatedUser>();
 
     for (const [stableUserId, userInfo] of this.deltaNetState.byStableId) {
       const connId = this.stableIdToConnectionId.get(stableUserId);
@@ -271,10 +304,36 @@ export class UserNetworkingClient {
       }
       if (!addedConnectionIds.has(connId)) {
         if (userInfo.components.size > 0) {
-          const clientUpdate = DeltaNetComponentMapping.fromComponents(userInfo.components);
-          updatedUsers.set(connId, {
-            components: clientUpdate,
-          });
+          // Mutate the per-connId pooled components in place. The same
+          // reference also lives downstream in
+          // `Networked3dWebExperienceClient.remoteUserStates` (set on the
+          // initial ADD), so the new values are visible to readers
+          // without us reseating the entry.
+          let pooledComponents = this._componentsPool.get(connId);
+          if (!pooledComponents) {
+            // Defensive: shouldn't happen — every active connId is
+            // seeded on add. Fall back to a fresh allocation.
+            pooledComponents = {
+              position: { x: 0, y: 0, z: 0 },
+              rotation: { eulerY: 0 },
+              state: 0,
+            };
+            this._componentsPool.set(connId, pooledComponents);
+          }
+          DeltaNetComponentMapping.fromComponentsInto(userInfo.components, pooledComponents);
+
+          // Reuse the per-connId UpdatedUser wrapper.
+          let pooledUpdated = this._updatedUserPool.get(connId);
+          if (!pooledUpdated) {
+            pooledUpdated = { components: pooledComponents };
+            this._updatedUserPool.set(connId, pooledUpdated);
+          } else {
+            pooledUpdated.components = pooledComponents;
+            // Clear any sticky userState left from a prior state-update
+            // tick on this connId.
+            pooledUpdated.userState = undefined;
+          }
+          updatedUsers.set(connId, pooledUpdated);
         }
       }
     }

--- a/packages/3d-web-user-networking/test/DeltaNetComponentMapping.test.ts
+++ b/packages/3d-web-user-networking/test/DeltaNetComponentMapping.test.ts
@@ -152,6 +152,42 @@ describe("DeltaNetComponentMapping", () => {
     });
   });
 
+  describe("fromComponentsInto", () => {
+    test("mutates the destination object and returns the same reference", () => {
+      const update: UserNetworkingClientUpdate = {
+        position: { x: 1.5, y: -2.75, z: 10.123 },
+        rotation: { eulerY: 0.5 },
+        state: 3,
+      };
+      const components = DeltaNetComponentMapping.toComponents(update);
+      const dest: UserNetworkingClientUpdate = {
+        position: { x: 99, y: 99, z: 99 },
+        rotation: { eulerY: 99 },
+        state: 99,
+      };
+      const result = DeltaNetComponentMapping.fromComponentsInto(components, dest);
+      expect(result).toBe(dest);
+      expect(dest.position.x).toBeCloseTo(1.5, 1);
+      expect(dest.position.y).toBeCloseTo(-2.75, 1);
+      expect(dest.position.z).toBeCloseTo(10.12, 1);
+      expect(dest.rotation.eulerY).toBeCloseTo(0.5, 2);
+      expect(dest.state).toBe(3);
+    });
+
+    test("preserves the dest's nested position/rotation refs across calls", () => {
+      const dest: UserNetworkingClientUpdate = {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { eulerY: 0 },
+        state: 0,
+      };
+      const positionRef = dest.position;
+      const rotationRef = dest.rotation;
+      DeltaNetComponentMapping.fromComponentsInto(new Map(), dest);
+      expect(dest.position).toBe(positionRef);
+      expect(dest.rotation).toBe(rotationRef);
+    });
+  });
+
   describe("toStates / fromUserStates round-trip", () => {
     test("round-trips username", () => {
       const userData: UserData = {


### PR DESCRIPTION
## Summary

Performance and plumbing changes for high-bot-count remote-character rendering.

### Collisions
- **Tight world-AABB cull in `CollisionsManager` queries** (`client-core`). The per-group setup before `meshBVH.shapecast`/`raycastFirst` (matrix invert + AABB transform) dominated main-thread physics time at high group counts; cache the world-space AABB per group and pre-cull capsule-vs-AABB / ray-vs-AABB so most groups skip the setup entirely.
- **`CollisionsManager.raycastAll`** (`client-core`). Click resolution previously routed through a separately-built per-def CollisionBVH that built lazily on the call stack and stalled the main thread. `raycastAll` returns every group's nearest hit, sorted, so clicks can reuse the per-handle BVHs already maintained for physics — no extra build, no main-thread stall.

### Render fast path / allocations
- **`skipRemoteCharacterUpdate` config flag** (`client-core`). When set, `CharacterManager` skips its remote-character loop and the renderer drives remotes directly from `RenderState.remoteUserStates`. Removes the two-pass shape (CharacterManager + renderer) when the renderer owns the pipeline end-to-end.
- **Forward `skipRemoteCharacterUpdate` + network state to the renderer** (`experience-client`). Glue for the above — exposes `remoteUserStates` and `localCharacterId` on `RenderState`.
- **Zero-alloc per-tick `processNetworkUpdate`** (`user-networking`). The per-tick update loop was the largest single per-tick JS allocation source; this pools the intermediate `UserNetworkingClientUpdate` objects and reuses them across ticks.
- **Per-tick allocation cleanups on the render hot path** (`client-core`, `experience-client`). The render path created closures and intermediate objects every frame; this shaves them.

### Plumbing
- **Plumb `getRemoteCharacterInfo` through `RenderState`** (`client-core`, `experience-client`). Renderers that own the remote-character pipeline need to resolve identity (username/description/colors) at spawn without reaching into private fields. Stable closure identity matters because some renderers pointer-compare and wire the resolver once — an inline arrow per frame would defeat that cache. Drops the now-duplicate `localConnectionId` field on `RenderState` (already on `localCharacterId`).
- **`AnimationState.emote` + optional `emoteAnimationFileUrl`** (`client-core`). Producers other than `LocalController` (e.g. headless bots) need a non-locomotion clip slot. Previously bots hijacked `AnimationState.running`, which forced consumers to globally remap the sprint animation URL — leaking emote behaviour onto the local player when sprinting.

### Fixes
- **Pass physics-consumed time as `deltaTimeSeconds`** (`experience-client`). Render is gated on `physicsUpdated`, so on high-refresh displays the raw rAF interval under-counts the simulated time actually advanced. Renderers that drive animations from `deltaTimeSeconds` saw under-counted dt and animations played at half speed.

## Test plan
- [ ] Existing CI green
- [ ] Manual smoke at high bot counts — no regression in click handling or remote character rendering