### PR TITLE
feat(experience-client): spawn local character ASAP, frozen until load completes

### DIFF
--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -205,7 +205,18 @@ export class LocalController {
     this.maximumZ = spawnConfig.respawnTrigger.maxZ;
   }
 
+  /** When true, `update` is a no-op — character holds position, ignores
+   *  input and gravity. Used to park the local player at spawn until the
+   *  world has finished loading. */
+  public frozen: boolean = false;
+
   public update(deltaTime: number): void {
+    if (this.frozen) {
+      // Keep velocity drained while parked so the unfreeze doesn't apply
+      // a sudden accumulated fall.
+      this.characterVelocity.set(0, 0, 0);
+      return;
+    }
     this.controlState =
       this.config.keyInputManager.getOutput() ||
       this.config.additionalInputProvider?.getOutput() ||

--- a/packages/3d-web-client-core/src/character/LocalController.ts
+++ b/packages/3d-web-client-core/src/character/LocalController.ts
@@ -205,18 +205,21 @@ export class LocalController {
     this.maximumZ = spawnConfig.respawnTrigger.maxZ;
   }
 
-  /** When true, `update` is a no-op — character holds position, ignores
-   *  input and gravity. Used to park the local player at spawn until the
-   *  world has finished loading. */
-  public frozen: boolean = false;
+  private frozen: boolean = false;
+
+  /** Park the character in place: no input, no gravity. Used to hold the
+   *  local player at spawn until the world has finished loading. */
+  public freeze(): void {
+    this.frozen = true;
+    this.characterVelocity.set(0, 0, 0);
+  }
+
+  public unfreeze(): void {
+    this.frozen = false;
+  }
 
   public update(deltaTime: number): void {
-    if (this.frozen) {
-      // Keep velocity drained while parked so the unfreeze doesn't apply
-      // a sudden accumulated fall.
-      this.characterVelocity.set(0, 0, 0);
-      return;
-    }
+    if (this.frozen) return;
     this.controlState =
       this.config.keyInputManager.getOutput() ||
       this.config.additionalInputProvider?.getOutput() ||

--- a/packages/3d-web-client-core/test/character/LocalController.test.ts
+++ b/packages/3d-web-client-core/test/character/LocalController.test.ts
@@ -291,4 +291,60 @@ describe("LocalController", () => {
       expect(controller.latestPosition).toBeDefined();
     });
   });
+
+  describe("freeze / unfreeze", () => {
+    test("update is a no-op when frozen", () => {
+      // Give the controller some vertical velocity via jump, then verify
+      // that after freeze() neither position nor velocity advance under
+      // update() — collisions/applyColliders must not run either.
+      controller.characterOnGround = true;
+      controller.jumpCounter = 0;
+      controller.jump();
+      expect(controller.verticalVelocity).toBeGreaterThan(0);
+
+      controller.freeze();
+      // freeze() itself zeroes velocity
+      expect(controller.verticalVelocity).toBe(0);
+
+      const startX = config.position.x;
+      const startY = config.position.y;
+      const startZ = config.position.z;
+      (config.collisionsManager.applyColliders as jest.Mock<any>).mockClear();
+      controller.update(0.016);
+      expect(config.position.x).toBe(startX);
+      expect(config.position.y).toBe(startY);
+      expect(config.position.z).toBe(startZ);
+      expect(controller.verticalVelocity).toBe(0);
+      expect(config.collisionsManager.applyColliders).not.toHaveBeenCalled();
+    });
+
+    test("update runs normally after unfreeze", () => {
+      controller.freeze();
+      controller.update(0.016);
+      (config.collisionsManager.applyColliders as jest.Mock<any>).mockClear();
+      controller.unfreeze();
+      controller.update(0.016);
+      expect(config.collisionsManager.applyColliders).toHaveBeenCalled();
+    });
+
+    test("freeze zeroes accumulated velocity", () => {
+      controller.characterOnGround = true;
+      controller.jumpCounter = 0;
+      controller.jump();
+      controller.setHorizontalVelocity(5, -3);
+      expect(controller.verticalVelocity).toBeGreaterThan(0);
+
+      controller.freeze();
+      expect(controller.verticalVelocity).toBe(0);
+      // Indirectly verify horizontal components are zeroed too: after
+      // unfreeze, a single update with no input should leave the
+      // character roughly in place rather than carry over the 5,-3.
+      controller.unfreeze();
+      const startX = config.position.x;
+      const startZ = config.position.z;
+      controller.update(0.016);
+      expect(Math.abs(config.position.x - startX)).toBeLessThan(0.01);
+      expect(Math.abs(config.position.z - startZ)).toBeLessThan(0.01);
+    });
+  });
 });

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -244,6 +244,13 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
           this.remoteUserStates.clear();
           this.connectionId = null;
           this.pendingChatMessages = [];
+          // Reset spawn-gate state so the local character is recreated after
+          // reconnect. WorldConnection clears `latestWorldConfig` on disconnect
+          // and the server re-emits `world_config`, so we mirror that here.
+          this.localCharacterSpawned = false;
+          this.initialLoadCompleted = false;
+          this.worldConfigReceived = false;
+          this.characterManager.localController?.unfreeze();
           break;
 
         case "identity_assigned":
@@ -252,7 +259,9 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
           // Set the local connection ID early to prevent the local character from being
           // spawned as a remote character when network updates arrive before loading completes
           this.characterManager.setLocalConnectionId(event.connectionId);
-          if (!this.config.waitForWorldConfig) {
+          if (!this.config.waitForWorldConfig && !this.initialLoadCompleted) {
+            // `completedLoadingAsset` doesn't dedupe; guard against re-fire on
+            // reconnect (which now re-emits identity_assigned).
             this.loadingProgressManager.completedLoadingAsset(initialNetworkLoadRef);
           }
           this.spawnCharacterIfReady();
@@ -380,6 +389,11 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
         this.initialLoadCompleted = true;
         if (this.connectionId === null || this.disposed) return;
 
+        // Unfreeze before plugins mount so they observe the post-load state
+        // of the controller (input enabled, gravity applied) rather than a
+        // parked one.
+        this.characterManager.localController?.unfreeze();
+
         for (const plugin of this.getAllPlugins()) {
           plugin.mount(this.element, this);
         }
@@ -392,9 +406,6 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
         }
 
         this.spawnCharacterIfReady();
-        if (this.characterManager.localController) {
-          this.characterManager.localController.frozen = false;
-        }
         this.emit("ready");
 
         // Replay chat messages that arrived before plugins were mounted
@@ -799,18 +810,25 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
   // connection id, our profile, and (when waitForWorldConfig) the world's
   // spawn config. Independent of `initialLoadCompleted` so a slow world
   // load doesn't keep the player off the wire.
+  private get readyToSpawn(): boolean {
+    return (
+      !this.localCharacterSpawned &&
+      !this.disposed &&
+      this.connectionId !== null &&
+      this.userProfiles.has(this.connectionId) &&
+      (!this.config.waitForWorldConfig || this.worldConfigReceived)
+    );
+  }
+
   private spawnCharacterIfReady(): void {
-    if (this.localCharacterSpawned || this.disposed) return;
-    if (this.connectionId === null) return;
-    if (!this.userProfiles.has(this.connectionId)) return;
-    if (this.config.waitForWorldConfig && !this.worldConfigReceived) return;
+    if (!this.readyToSpawn) return;
     this.localCharacterSpawned = true;
     this.spawnCharacter(getSpawnData(this.spawnConfiguration, true));
     // If the world hasn't finished loading yet, park the character at spawn
     // (no gravity, no input) so they don't fall through unloaded geometry.
-    // The loading-complete callback thaws them when ready.
-    if (!this.initialLoadCompleted && this.characterManager.localController) {
-      this.characterManager.localController.frozen = true;
+    // The loading-complete callback unfreezes them when ready.
+    if (!this.initialLoadCompleted) {
+      this.characterManager.localController?.freeze();
     }
   }
 

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -810,18 +810,12 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
   // connection id, our profile, and (when waitForWorldConfig) the world's
   // spawn config. Independent of `initialLoadCompleted` so a slow world
   // load doesn't keep the player off the wire.
-  private get readyToSpawn(): boolean {
-    return (
-      !this.localCharacterSpawned &&
-      !this.disposed &&
-      this.connectionId !== null &&
-      this.userProfiles.has(this.connectionId) &&
-      (!this.config.waitForWorldConfig || this.worldConfigReceived)
-    );
-  }
-
   private spawnCharacterIfReady(): void {
-    if (!this.readyToSpawn) return;
+    if (this.localCharacterSpawned) return;
+    if (this.disposed) return;
+    if (this.connectionId === null) return;
+    if (!this.userProfiles.has(this.connectionId)) return;
+    if (this.config.waitForWorldConfig && !this.worldConfigReceived) return;
     this.localCharacterSpawned = true;
     this.spawnCharacter(getSpawnData(this.spawnConfiguration, true));
     // If the world hasn't finished loading yet, park the character at spawn

--- a/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
+++ b/packages/3d-web-experience-client/src/Networked3dWebExperienceClient.ts
@@ -145,6 +145,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
   private characterControllerValues = createDefaultCharacterControllerValues();
 
   private initialLoadCompleted = false;
+  private localCharacterSpawned = false;
   private pendingChatMessages: {
     username: string;
     message: string;
@@ -251,11 +252,10 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
           // Set the local connection ID early to prevent the local character from being
           // spawned as a remote character when network updates arrive before loading completes
           this.characterManager.setLocalConnectionId(event.connectionId);
-          if (this.initialLoadCompleted) {
-            this.spawnCharacter(getSpawnData(this.spawnConfiguration, true));
-          } else if (!this.config.waitForWorldConfig) {
+          if (!this.config.waitForWorldConfig) {
             this.loadingProgressManager.completedLoadingAsset(initialNetworkLoadRef);
           }
+          this.spawnCharacterIfReady();
           break;
 
         case "server_error":
@@ -317,6 +317,7 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
           // client is not blocked indefinitely — it will use defaults.
           this.worldConfigReceived = true;
           this.checkReadyForInitialLoad();
+          this.spawnCharacterIfReady();
           break;
         }
 
@@ -390,7 +391,10 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
           plugin.onConfigChanged?.(this.latestConfig);
         }
 
-        this.spawnCharacter(getSpawnData(this.spawnConfiguration, true));
+        this.spawnCharacterIfReady();
+        if (this.characterManager.localController) {
+          this.characterManager.localController.frozen = false;
+        }
         this.emit("ready");
 
         // Replay chat messages that arrived before plugins were mounted
@@ -651,6 +655,10 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
       }
       this.remoteUserStates.set(connId, userDataUpdate.components);
     }
+    // Our profile may have just arrived in addedConnectionIds — spawn the
+    // local character now if the rest of the gate (connection id, world
+    // config when waited-for) is satisfied.
+    this.spawnCharacterIfReady();
   }
 
   private sendIdentityUpdateToServer(
@@ -785,6 +793,25 @@ export class Networked3dWebExperienceClient extends ClientEventEmitter {
 
     // Render the actual frame using the associated renderer
     this.renderer.render(renderState);
+  }
+
+  // Spawns the local character as soon as we have everything we need —
+  // connection id, our profile, and (when waitForWorldConfig) the world's
+  // spawn config. Independent of `initialLoadCompleted` so a slow world
+  // load doesn't keep the player off the wire.
+  private spawnCharacterIfReady(): void {
+    if (this.localCharacterSpawned || this.disposed) return;
+    if (this.connectionId === null) return;
+    if (!this.userProfiles.has(this.connectionId)) return;
+    if (this.config.waitForWorldConfig && !this.worldConfigReceived) return;
+    this.localCharacterSpawned = true;
+    this.spawnCharacter(getSpawnData(this.spawnConfiguration, true));
+    // If the world hasn't finished loading yet, park the character at spawn
+    // (no gravity, no input) so they don't fall through unloaded geometry.
+    // The loading-complete callback thaws them when ready.
+    if (!this.initialLoadCompleted && this.characterManager.localController) {
+      this.characterManager.localController.frozen = true;
+    }
   }
 
   private spawnCharacter({


### PR DESCRIPTION
## Why

Two pieces of plumbing that together let load happen *around* the player instead of *in front of* the player.

- **Freeze the local character on spawn until load completes.** Without this, the character spawns with gravity/input live before world geometry is in the physics world and falls through unloaded floor. The way that was previously avoided was by holding the spawn until everything was loaded — which serialises the user's entire experience behind world LOD-0. With freeze, spawn can happen as soon as identity is on the wire and the character holds position safely while the rest streams in.
- **Spawn the local character as soon as identity + profile (+ `world_config` when waited-for) are available — independent of `initialLoadCompleted`.** Lets downstream consumers (asset prioritiser, frustum culling) read the real player position from frame 1 of streaming instead of running against a default camera. That means LOD selection and asset priority are correct *during* load, not after it.

Net effect: loading can be reordered around the player's actual location, the user isn't stuck behind a multi-minute loading screen on busy worlds, and falling-through-geometry isn't a tradeoff for early spawn.